### PR TITLE
Add basic guide for splash screens and icons

### DIFF
--- a/docs-md/README.md
+++ b/docs-md/README.md
@@ -24,6 +24,7 @@
   * [Push Notifications - Firebase](guides/push-notifications-firebase.md)
   * [Deep Links](guides/deep-links.md)
   * [Deploying and Updating](guides/deploying.md)
+  * [Splash Screens and Icons](guides/splash-screens-icons.md)
   * [Community Guides](guides/community.md)
 * iOS
   * [Getting Started](ios/index.md)

--- a/docs-md/android/deploying-to-google-play.md
+++ b/docs-md/android/deploying-to-google-play.md
@@ -10,7 +10,7 @@ contributors:
 
 Because Capacitor apps are normal native apps at the end of the day, the way they are deployed to the Google Play Store is just like any other native Android app.
 
-To start, consult the official Google documentation on the [launch checklist](https://developer.android.com/distribute/best-practices/launch/launch-checklist) to get your app ready for submission.
+To start, consult the official Google documentation on the [launch checklist](https://developer.android.com/distribute/best-practices/launch/launch-checklist) to get your app ready for submission. [See here](/docs/guides/splash-screens-and-icons) for details on generating splash screens and icons for your app.
 
 For a guide with some Capacitor-specific considerations, see [Josh Morony's wonderful guide](https://www.joshmorony.com/deploying-capacitor-applications-to-android-development-distribution/) on the topic.
 

--- a/docs-md/cordova/migrating-from-cordova-to-capacitor.md
+++ b/docs-md/cordova/migrating-from-cordova-to-capacitor.md
@@ -68,7 +68,22 @@ Both android and ios folders at the root of the project are created. These are e
 
 ## Splash Screens and Icons
 
-If you've previously created icon and splash screen images, they can be found in the top-level `resources` folder of your project. [Follow this guide](https://www.joshmorony.com/adding-icons-splash-screens-launch-images-to-capacitor-projects/) to move them over to each native project.
+If you've previously created icon and splash screen images, they can be found in the top-level `resources` folder of your project. With those images in place, you can use the `cordova-res` tool to generate icons and splash screens for Capacitor-based iOS and Android projects.
+
+First, install `cordova-res`:
+
+```bash
+$ npm install -g cordova-res
+```
+
+Next, run the following to regenerate the images and copy them into the native projects:
+
+```bash
+$ cordova-res ios --skip-config --copy
+$ cordova-res android --skip-config --copy
+```
+
+[Complete details here](https://github.com/ionic-team/cordova-res#capacitor).
 
 ## Migrate Plugins
 

--- a/docs-md/guides/splash-screens-and-icons.md
+++ b/docs-md/guides/splash-screens-and-icons.md
@@ -1,0 +1,32 @@
+---
+title: Creating Splash Screens and Icons
+description: Use cordova-res to generate resource images for native projects
+url: /docs/guides/splash-screens-and-icons
+contributors:
+  - dotnetkow
+---
+
+#  Creating Splash Screens and Icons
+
+Initial support for splash screen and icon generation is now available. For complete details, see the [cordova-res docs](https://github.com/ionic-team/cordova-res).
+
+First, install `cordova-res`:
+
+```bash
+$ npm install -g cordova-res
+```
+
+`cordova-res` expects a Cordova-like structure: place one icon and one splash screen file in a top-level `resources` folder within your project, like so:
+
+```
+resources/
+├── icon.png
+└── splash.png
+```
+
+Next, run the following to generate all images then copy them into the native projects:
+
+```bash
+$ cordova-res ios --skip-config --copy
+$ cordova-res android --skip-config --copy
+```

--- a/docs-md/ios/deploying-to-app-store.md
+++ b/docs-md/ios/deploying-to-app-store.md
@@ -10,7 +10,7 @@ contributors:
 
 Because Capacitor apps are normal native apps at the end of the day, the way they are deployed to the App Store is just like any other native app.
 
-To start, consult the official Apple documentation on [Submitting Apps to the App Store](https://developer.apple.com/app-store/submissions/).
+To start, consult the official Apple documentation on [Submitting Apps to the App Store](https://developer.apple.com/app-store/submissions/). [See here](/docs/guides/splash-screens-and-icons) for details on generating splash screens and icons for your app.
 
 For a guide with some Capacitor-specific considerations, see [Josh Morony's wonderful guide](https://www.joshmorony.com/deploying-capacitor-applications-to-ios-development-distribution/) on the topic.
 


### PR DESCRIPTION
This was approved and merged into the original Capacitor docs - just moving this over.  Only new addition is mentioning/linking to the guide on the ios and android app store deployment pages