### PR TITLE
docs(deep-links): add nuxtjs instructions

### DIFF
--- a/docs-md/guides/deep-links.md
+++ b/docs-md/guides/deep-links.md
@@ -287,6 +287,10 @@ Place the association files under `src/.well-known`. Next, configure the build p
 
 Build then deploy the site.
 
+### NuxtJS
+
+Place the association files under `static/.well-known`. No additional steps are necessary; simply build then deploy the site.
+
 ### React
 
 Place the association files under `public/.well-known`. No additional steps are necessary; simply build then deploy the site.


### PR DESCRIPTION
As requested from @dwieeb, I am adding NuxtJS from my old pull request (https://github.com/ionic-team/capacitor/pull/2964).

Added instructions for those who ❤️ NuxtJS.

Added it in alphabetical order 👍