### PR TITLE
Add CLI commands reference page

### DIFF
--- a/docs-md/README.md
+++ b/docs-md/README.md
@@ -13,6 +13,7 @@
   * [Using Plugins](basics/using-plugins.md)
   * [Native Project Configuration](basics/configuring-your-app.md)
   * [Progressive Web Apps](basics/progressive-web-app.md)
+  * [CLI Reference](basics/cli-commands.md)
 * Cordova/PhoneGap
   * [Introduction](cordova/index.md)
   * [Migration Strategy](cordova/migration-strategy.md)

--- a/docs-md/basics/cli-commands.md
+++ b/docs-md/basics/cli-commands.md
@@ -118,8 +118,8 @@ npx cap init [options] [appName] [appId]
 - `appId` (optional): App Package Id (in Java package format, no dashes), such as `com.example.app`
 
 <strong>Options:</strong>
- - `--web-dir [value]`: Directory of your project's built web assets (default: `www`)
- - `--npm-client [npmClient]`: npm client to use for dependency installation
+ - `--web-dir <value>`: Directory of your project's built web assets (default: `www`)
+ - `--npm-client <npmClient>`: npm client to use for dependency installation
 
 ## List
 

--- a/docs-md/basics/cli-commands.md
+++ b/docs-md/basics/cli-commands.md
@@ -77,7 +77,7 @@ npx @capacitor/cli create [options] [directory] [name] [id]
 - `id` (optional): App Package Id (in Java package format, no dashes), such as `com.example.app`
 
 <strong>Options:</strong>
-- `--npm-client [npmClient]`: npm client to use for dependency installation
+- `--npm-client <npmClient>`: npm client to use for dependency installation
 
 ## Doctor
 
@@ -214,4 +214,3 @@ npx cap update
 
 <strong>Options:</strong>
 - `--deployment`: Podfile.lock won't be deleted and pod install will use `--deployment` option.
-

--- a/docs-md/basics/cli-commands.md
+++ b/docs-md/basics/cli-commands.md
@@ -24,7 +24,7 @@ npm install @capacitor/core @capacitor/cli
 Add a native platform project to your project.
 
 ```bash
-npx cap add [platform]
+npx cap add <platform>
 ```
 
 <strong>Inputs:</strong>
@@ -214,5 +214,4 @@ npx cap update
 
 <strong>Options:</strong>
 - `--deployment`: Podfile.lock won't be deleted and pod install will use `--deployment` option.
-
 

--- a/docs-md/basics/cli-commands.md
+++ b/docs-md/basics/cli-commands.md
@@ -1,0 +1,218 @@
+---
+title: CLI Commands 
+description: Capacitor CLI command reference list
+url: /docs/basics/cli-commands
+contributors:
+  - dotnetkow
+---
+
+# Capacitor CLI Reference
+
+<p class="intro">The Capacitor command-line interface (CLI) tool is used to develop Capacitor apps.</p>
+
+## Installation
+
+Capacitor does not use a global CLI. Instead, CLI is installed locally into each project as an npm script. This makes it easier to manage versions of Capacitor across many different apps.
+
+```bash
+cd my-app
+npm install @capacitor/core @capacitor/cli
+```
+
+## Add
+
+Add a native platform project to your project.
+
+```bash
+npx cap add [platform]
+```
+
+<strong>Inputs:</strong>
+- `platform` (required): `android`, `ios`
+
+## Cap
+
+View all available CLI commands and options.
+
+```bash
+npx cap [-V] [-h]
+```
+
+<strong>Options:</strong>
+- `-V, --version` (optional): Output the version number
+- `-h, --help` (optional): Output usage information. Can be used with individual commands too.
+
+## Copy
+
+Copy the web app build and Capacitor configuration file into the native platform project. Run this each time you make changes to your web app or change a configuration value in `capacitor.config.json`.
+
+```bash
+npx cap copy [platform]
+```
+
+<strong>Inputs:</strong>
+- `platform` (optional): `android`, `ios`
+
+<strong>Example output:</strong>
+```
+√ Copying web assets from www to android\app\src\main\assets\public in 2.64s
+√ Copying web assets from www to ios/App/public in 450ms
+√ Copying native bridge in 7.32ms
+√ Copying capacitor.config.json in 3.22ms
+√ copy in 2.74s
+√ copy in 1.10ms
+```
+
+## Create
+
+Create a new Capacitor project with a stock project structure if you'd rather start fresh and plan to add a UI/frontend framework separately.
+
+```bash
+npx @capacitor/cli create [options] [directory] [name] [id]
+```
+
+<strong>Inputs:</strong>
+- `directory` (optional): Directory to create the new app in, such as `c:\src\myapp` 
+- `name` (optional): App name
+- `id` (optional): App Package Id (in Java package format, no dashes), such as `com.example.app`
+
+<strong>Options:</strong>
+- `--npm-client [npmClient]`: npm client to use for dependency installation
+
+## Doctor
+
+Check each native project for common errors and compare the latest Capacitor dependencies available with the currently installed dependencies.
+
+```bash
+npx cap doctor [platform]
+```
+
+<strong>Inputs:</strong>
+- `platform` (optional): `android`, `ios`
+
+<strong>Example output:</strong>
+```
+Latest Dependencies:
+  @capacitor/cli: 2.2.0
+  @capacitor/core: 2.2.0
+  @capacitor/android: 2.2.0
+  @capacitor/ios: 2.2.0
+
+Installed Dependencies:
+  @capacitor/ios not installed
+  @capacitor/cli 2.1.0
+  @capacitor/core 2.1.0
+  @capacitor/android 2.1.0
+```
+
+## Init
+
+Initialize a new Capacitor project within an existing web app. All provided values (App name, App Id, WebDir, etc.) are written to `capacitor.config.json`.
+
+```bash
+npx cap init [options] [appName] [appId]
+```
+
+<strong>Inputs:</strong>
+- `appName` (optional): Name of app
+- `appId` (optional): App Package Id (in Java package format, no dashes), such as `com.example.app`
+
+<strong>Options:</strong>
+ - `--web-dir [value]`: Directory of your project's built web assets (default: `www`)
+ - `--npm-client [npmClient]`: npm client to use for dependency installation
+
+## List
+
+List all installed Cordova and Capacitor plugins.
+
+```bash
+npx cap ls [platform]
+```
+
+<strong>Inputs:</strong>
+- `platform` (optional): `android`, `ios`
+
+<strong>Example output:</strong>
+```
+Found 1 Capacitor plugin for android:
+    capacitor-mapbox (0.0.1)
+Found 2 Cordova plugins for android:
+    cordova-plugin-camera
+    cordova-plugin-splashscreen
+```
+
+## Open
+
+Opens the native project workspace in the specified native IDE (Xcode for iOS, Android Studio for Android). Once open, use the native IDEs to build, simulate, and run your app on a device.
+
+```bash
+npx cap open [platform]
+```
+
+<strong>Inputs:</strong>
+- `platform` (required): `android`, `ios`
+
+## Plugin Generate
+
+Create a new custom Capacitor plugin. This starts a wizard that prompts you for information about your new plugin. More information on developing plugins [here](/docs/plugins).
+
+```bash
+# Capacitor CLI already installed in project
+npx cap plugin:generate
+
+# Capacitor CLI not installed
+npx @capacitor/cli plugin:generate
+```
+
+## Serve
+
+Serves a Capacitor Progressive Web App in the browser, using the `webDir` directory specified in `capacitor.config.json`.
+
+```bash
+npx cap serve
+```
+
+## Sync
+
+Run the [Copy](#copy) and [Update](#update) commands together.
+
+```bash
+npx cap sync [options] [platform]
+```
+
+<strong>Inputs:</strong>
+- `platform` (optional): `android`, `ios`
+
+<strong>Options:</strong>
+- `--deployment`: Podfile.lock won't be deleted and pod install will use `--deployment` option.
+
+<strong>Example output:</strong>
+```
+√ Copying web assets from www to android\app\src\main\assets\public in 3.37s
+√ Copying native bridge in 5.80ms
+√ Copying capacitor.config.json in 2.59ms
+√ copy in 3.43s
+√ Updating Android plugins in 11.48ms
+  Found 1 Capacitor plugin for android:
+    capacitor-mapbox (0.0.1)
+√ update android in 105.91ms
+√ copy in 409.80μp
+√ update web in 6.80μp
+Sync finished in 3.563s
+```
+
+## Update
+
+Updates the native plugins and dependencies referenced in `package.json`.
+
+```bash
+npx cap update
+```
+
+<strong>Inputs:</strong>
+- `platform` (optional): `android`, `ios`
+
+<strong>Options:</strong>
+- `--deployment`: Podfile.lock won't be deleted and pod install will use `--deployment` option.
+
+

--- a/docs-md/basics/cli-commands.md
+++ b/docs-md/basics/cli-commands.md
@@ -8,16 +8,7 @@ contributors:
 
 # Capacitor CLI Reference
 
-<p class="intro">The Capacitor command-line interface (CLI) tool is used to develop Capacitor apps.</p>
-
-## Installation
-
-Capacitor does not use a global CLI. Instead, CLI is installed locally into each project as an npm script. This makes it easier to manage versions of Capacitor across many different apps.
-
-```bash
-cd my-app
-npm install @capacitor/core @capacitor/cli
-```
+<p class="intro">The Capacitor command-line interface (CLI) tool is used to develop Capacitor apps. View installation details <a href="/docs/getting-started">here</a>.</p>
 
 ## Add
 

--- a/docs-md/basics/cli-commands.md
+++ b/docs-md/basics/cli-commands.md
@@ -146,7 +146,7 @@ Found 2 Cordova plugins for android:
 Opens the native project workspace in the specified native IDE (Xcode for iOS, Android Studio for Android). Once open, use the native IDEs to build, simulate, and run your app on a device.
 
 ```bash
-npx cap open [platform]
+npx cap open <platform>
 ```
 
 <strong>Inputs:</strong>


### PR DESCRIPTION
The Capacitor CLI commands are sprinkled throughout the docs, but there's no main reference list like with the Ionic CLI.

This PR adds a dedicated page under the Basics section. Manually created for now, in the future we could automate it with a template.

I added helpful usage details - please call out any additional details worth adding, if any.

Played around with various formatting - I think what I landed on looks clean, easy to read, etc.

Direct page here: https://capacitor-site-git-cli-commands.ionic1.vercel.app/docs/basics/cli-commands