### PR TITLE
fix(header-menu): follow order of capacitor-site-footer

### DIFF
--- a/src/components/docs-header/docs-header.tsx
+++ b/src/components/docs-header/docs-header.tsx
@@ -24,8 +24,8 @@ export class DocsHeader implements ComponentInterface {
           <a {...href('/docs')} class={{ 'active': this.isActive('/docs') }}>Docs</a>
           {/* TODO enable this when we move the plugins */}
           {/* <a {...href('/plugins')} class={{ 'active': this.isActive('/plugins') }}>Plugins</a> */}
-          <a {...href('/blog')}>Blog</a>
           <a {...href('/community')}>Community</a>
+          <a {...href('/blog')}>Blog</a>
         </div>
         <div class="docs-header__link-divider"/>
         <div class="docs-header__external-links">


### PR DESCRIPTION
capacitor-site-header menu's order is `community > blog` :

<img width="771" alt="スクリーンショット 2020-07-06 16 45 12" src="https://user-images.githubusercontent.com/9690024/86568616-18d14400-bfa8-11ea-83bb-c5ce44a96a5d.png">

But docs-header's order is `blog > community`:

<img width="259" alt="スクリーンショット 2020-07-06 16 45 19" src="https://user-images.githubusercontent.com/9690024/86568624-1a9b0780-bfa8-11ea-9e3c-631ad80d8011.png">

This pullrequest fix this.