### PR TITLE
Add Ionic Photo Gallery App guide to the menu

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -26,6 +26,7 @@
   * [Deep Links](guides/deep-links.md)
   * [Deploying and Updating](guides/deploying.md)
   * [In App Purchases](guides/in-app-purchases.md)
+  * [Ionic Photo Gallery App](guides/ionic-framework-app.md)
   * [Live Reload](guides/live-reload.md)
   * [Push Notifications - Firebase](guides/push-notifications-firebase.md)
   * [React Hooks](guides/react-hooks.md)


### PR DESCRIPTION
This guide link was removed (not sure if on purpose or by mistake) from the "Concepts" menu.

If the guide is not linked, it doesn't get built despite the file is there. There are 3 different links that get broken because of that. (one of them reported on https://github.com/ionic-team/capacitor-site/issues/94)

If we don't want the guide to be listed, maybe we should link to the ionic guide (https://ionicframework.com/docs/intro/next) and remove the file.

Closes https://github.com/ionic-team/capacitor-site/issues/94

