### PR TITLE
Remove PWA supported icon from Splash Screen Documents

### DIFF
--- a/docs/reference/apis/splash-screen/index.md
+++ b/docs/reference/apis/splash-screen/index.md
@@ -8,7 +8,7 @@ contributors:
   - trancee
 ---
 
-<plugin-platforms platforms="pwa,ios,android"></plugin-platforms>
+<plugin-platforms platforms="ios,android"></plugin-platforms>
 
 # Splash Screen
 


### PR DESCRIPTION
Splash Screen component does not provide any functionality for PWAs.