### PR TITLE
Removed deprecated `pluginError` event listener

### DIFF
--- a/pages/docs/apis/app/index.md
+++ b/pages/docs/apis/app/index.md
@@ -49,11 +49,6 @@ App.addListener('appStateChange', (state: AppState) => {
   console.log('App state changed. Is active?', state.isActive);
 });
 
-// Listen for serious plugin errors
-App.addListener('pluginError', (info: any) => {
-  console.error('There was a serious error with a plugin', err, info);
-});
-
 var ret = await App.canOpenUrl({ url: 'com.getcapacitor.myapp' });
 console.log('Can open url: ', ret.value);
 


### PR DESCRIPTION
Seems like it's been removed for quite a while now:
https://github.com/ionic-team/capacitor/commit/ab72bbcf2f37a5f49360f5c2bd481cb6f51c66ff