### PR TITLE
Update example code in index.md

### DIFF
--- a/pages/docs/apis/local-notifications/index.md
+++ b/pages/docs/apis/local-notifications/index.md
@@ -38,6 +38,13 @@ Local Notifications are great for reminding the user about a change in the app s
 import { Plugins } from '@capacitor/core';
 const { LocalNotifications } = Plugins;
 
+// ask user for permissions to send notification messages. 
+if (!LocalNotifications.requestPermissions) {
+  LocalNotifications.requestPermission().then( result => {
+    console.log('request', result);
+  })
+}
+
 const notifs = await LocalNotifications.schedule({
   notifications: [
     {


### PR DESCRIPTION
New Capacitor devs like me may run into the "requests for permission" moment. No error is provided, events are firing correctly, but notification do not show up. Just after permission was granted, you will have rest of the example work. I added the lines to request permissions if not set already.