### PR TITLE
fix(iOS): update screen orientation instructions

### DIFF
--- a/pages/docs/guides/screen-orientation.md
+++ b/pages/docs/guides/screen-orientation.md
@@ -15,9 +15,21 @@ To set a global setting for orientation in your Capacitor app, you'll set the co
 
 ### iOS Configuration
 
-To limit the allowed orientations for iOS, open Xcode and open the general settings for the project. Then, select the orientations your app will support:
+iOS allows for different screen orientations to be supported on iPhones and iPads. To limit the allowed orientations for iOS, open Xcode and open the `Info.plist` file. Find the following keys: `Supported interface orientation` and `Supported interface orientation (iPad)`. Using these values, specify the different orientations you would like supported for iPhones and for iPads.
 
-![Orientation Settings on iOS](/assets/img/docs/guides/screen-orientation/ios.png)
+If editting the `Info.plist` file directly (not via Xcode), look for the following keys: `UISupportedInterfaceOrientations` and `UISupportedInterfaceOrientations~ipad`. For example, the following settings will limit the orientation to right-side-up `Portrait` on iPhones and either of the `Landscape` orientations on iPads:
+
+```
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+  </array>
+  <key>UISupportedInterfaceOrientations~ipad</key>
+  <array>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+  </array>
+```
 
 ### Android Configuration
 

--- a/pages/docs/guides/screen-orientation.md
+++ b/pages/docs/guides/screen-orientation.md
@@ -17,7 +17,7 @@ To set a global setting for orientation in your Capacitor app, you'll set the co
 
 iOS allows for different screen orientations to be supported on iPhones and iPads. To limit the allowed orientations for iOS, open Xcode and open the `Info.plist` file. Find the following keys: `Supported interface orientation` and `Supported interface orientation (iPad)`. Using these values, specify the different orientations you would like supported for iPhones and for iPads.
 
-If editting the `Info.plist` file directly (not via Xcode), look for the following keys: `UISupportedInterfaceOrientations` and `UISupportedInterfaceOrientations~ipad`. For example, the following settings will limit the orientation to right-side-up `Portrait` on iPhones and either of the `Landscape` orientations on iPads:
+If editting the `Info.plist` file directly look for the following keys: `UISupportedInterfaceOrientations` and `UISupportedInterfaceOrientations~ipad`. For example, the following settings will limit the orientation to right-side-up `Portrait` on iPhones and either of the `Landscape` orientations on iPads:
 
 ```
   <key>UISupportedInterfaceOrientations</key>

--- a/pages/docs/v3/guides/screen-orientation.md
+++ b/pages/docs/v3/guides/screen-orientation.md
@@ -15,9 +15,21 @@ To set a global setting for orientation in your Capacitor app, you'll set the co
 
 ### iOS Configuration
 
-To limit the allowed orientations for iOS, open Xcode and open the general settings for the project. Then, select the orientations your app will support:
+iOS allows for different screen orientations to be supported on iPhones and iPads. To limit the allowed orientations for iOS, open Xcode and open the `Info.plist` file. Find the following keys: `Supported interface orientation` and `Supported interface orientation (iPad)`. Using these values, specify the different orientations you would like supported for iPhones and for iPads.
 
-![Orientation Settings on iOS](/assets/img/docs/guides/screen-orientation/ios.png)
+If editting the `Info.plist` file directly look for the following keys: `UISupportedInterfaceOrientations` and `UISupportedInterfaceOrientations~ipad`. For example, the following settings will limit the orientation to right-side-up `Portrait` on iPhones and either of the `Landscape` orientations on iPads:
+
+```
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+  </array>
+  <key>UISupportedInterfaceOrientations~ipad</key>
+  <array>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+  </array>
+```
 
 ### Android Configuration
 


### PR DESCRIPTION
iOS allows for different orientations on iOS and on iPad. The previous documentation used the "General" tab which only affects the iPhone settings but not the iPad settings. Modifying the info.plist file directly allows the user to set this appropriately for each system.

Fixes: #177 