### PR TITLE
Update deep-links.md for automatic app signing

### DIFF
--- a/pages/docs/guides/deep-links.md
+++ b/pages/docs/guides/deep-links.md
@@ -236,9 +236,11 @@ Android configuration involves creating a site association file and configuring 
 
 ### Create Site Association File
 
-The Site Association file requires the SHA256 fingerprint of your Android certificate.
+The Site Association file requires the SHA256 fingerprint of your Android certificate.  
 
-If you don’t have one, create a certificate:
+If you have enabled automatic signing in the Google Play Store, you can get your SHA256 certificate by going to https://play.google.com/console, selecting your app, Setup, App Signing, and copying your SHA256 app signing certificate thumbprint.
+
+If you have not signed your app or enabled automatic signing and do not already have a certificate, you can create a new certificate:
 
 ```shell
 keytool -genkey -v -keystore KEY-NAME.keystore -alias ALIAS -keyalg RSA -keysize 2048 -validity 10000


### PR DESCRIPTION
Google Play Store offers automatic app signing.  If this is enabled, then the automatic signing certificate's SHA256 should be used in assetlinks.json.