### PR TITLE
Update workflow.md

### DIFF
--- a/pages/docs/plugins/workflow.md
+++ b/pages/docs/plugins/workflow.md
@@ -85,8 +85,8 @@ First, within the plugin folder, run: `npm link`.
 Then, within the project that will test the plugin, run:
 
 ```bash
-$ npm link plugin-name
 $ npm install plugin-name
+$ npm link plugin-name
 ```
 
 The project's `package.json` file now shows the plugin package link in the dependencies list:


### PR DESCRIPTION
If plugin already exists in npm repo, doing npm install after npm link will simply pull plugin from the repo and overwrite symbolic link.