### PR TITLE
Add Push Notifications API change

### DIFF
--- a/pages/docs/v3/updating/3-0.md
+++ b/pages/docs/v3/updating/3-0.md
@@ -117,7 +117,7 @@ While many of the plugin APIs remain the same to ease the migration process to C
   - This plugin is now using the new Permissions API. `requestPermission()` was removed, use `requestPermissions()`.
 - **Push Notifications**
   - This plugin is now using the new Permissions API. `requestPermission()` was removed, use `requestPermissions()`.
-  - `PushNotification` was renamed to `PushNotificationSchema`
+  - `PushNotification` was renamed to `PushNotificationSchema`.
 - **Share**
   - `share()` method now returns `ShareResult` instead of `any`
   - The return value of `share()` will no longer include `completed`. If it was not completed, it will reject instead.

--- a/pages/docs/v3/updating/3-0.md
+++ b/pages/docs/v3/updating/3-0.md
@@ -117,6 +117,7 @@ While many of the plugin APIs remain the same to ease the migration process to C
   - This plugin is now using the new Permissions API. `requestPermission()` was removed, use `requestPermissions()`.
 - **Push Notifications**
   - This plugin is now using the new Permissions API. `requestPermission()` was removed, use `requestPermissions()`.
+  - `PushNotification` was renamed to `PushNotificationSchema`
 - **Share**
   - `share()` method now returns `ShareResult` instead of `any`
   - The return value of `share()` will no longer include `completed`. If it was not completed, it will reject instead.


### PR DESCRIPTION
Following the Push Notifications with Firebase guide, it used `PushNotification`, but that type no longer exist, it has been renamed to `PushNotificationSchema`