### PR TITLE
Update Firebase tutorial for Capacitor 3

### DIFF
--- a/pages/docs/v3/guides/push-notifications-firebase.md
+++ b/pages/docs/v3/guides/push-notifications-firebase.md
@@ -76,19 +76,24 @@ Upon running these commands, both `android` and `ios` folders at the root of the
 
 ## Using the Capacitor Push Notification API
 
-Before we get to Firebase, we'll need to ensure that our application can register for push notifications by making use of the Capacitor Push Notification API. We'll also add an `alert` (you could use `console.log` statements instead) to show us the payload for a notification when it arrives and the app is open on our device.
+First of all, we need to install the Capacitor Push Notifications Plugin
+
+```bash
+npm install @capacitor/push-notifications
+npx cap sync
+```
+
+Then, before we get to Firebase, we'll need to ensure that our application can register for push notifications by making use of the Capacitor Push Notification API. We'll also add an `alert` (you could use `console.log` statements instead) to show us the payload for a notification when it arrives and the app is open on our device.
 
 In your app, head to the `home.page.ts` file and add an `import` statement and a `const` to make use of the Capacitor Push API:
 
 ```typescript
 import {
-  Plugins,
-  PushNotification,
+  PushNotificationSchema,
+  PushNotifications,
   PushNotificationToken,
   PushNotificationActionPerformed,
-} from '@capacitor/core';
-
-const { PushNotifications } = Plugins;
+} from '@capacitor/push-notifications';
 ```
 
 Then, add the `ngOnInit()` method with some API methods to register and monitor for push notifications. We will also add an `alert()` a few of the events to monitor what is happening:
@@ -102,8 +107,8 @@ ngOnInit() {
     // Request permission to use push notifications
     // iOS will prompt user and return if they granted permission or not
     // Android will just grant without prompting
-    PushNotifications.requestPermission().then( result => {
-      if (result.granted) {
+    PushNotifications.requestPermissions().then(result => {
+      if (result.receive === 'granted') {
         // Register with Apple / Google to receive push via APNS/FCM
         PushNotifications.register();
       } else {
@@ -127,7 +132,7 @@ ngOnInit() {
 
     // Show us the notification payload if the app is open on our device
     PushNotifications.addListener('pushNotificationReceived',
-      (notification: PushNotification) => {
+      (notification: PushNotificationSchema) => {
         alert('Push received: ' + JSON.stringify(notification));
       }
     );
@@ -147,13 +152,11 @@ Here is the full implementation of `home.page.ts`:
 import { Component, OnInit } from '@angular/core';
 
 import {
-  Plugins,
-  PushNotification,
+  PushNotificationSchema,
+  PushNotifications,
   PushNotificationToken,
   PushNotificationActionPerformed,
-} from '@capacitor/core';
-
-const { PushNotifications } = Plugins;
+} from '@capacitor/push-notifications';
 
 @Component({
   selector: 'app-home',
@@ -167,8 +170,8 @@ export class HomePage implements OnInit {
     // Request permission to use push notifications
     // iOS will prompt user and return if they granted permission or not
     // Android will just grant without prompting
-    PushNotifications.requestPermission().then(result => {
-      if (result.granted) {
+    PushNotifications.requestPermissions().then(result => {
+      if (result.receive === 'granted') {
         // Register with Apple / Google to receive push via APNS/FCM
         PushNotifications.register();
       } else {
@@ -189,7 +192,7 @@ export class HomePage implements OnInit {
 
     PushNotifications.addListener(
       'pushNotificationReceived',
-      (notification: PushNotification) => {
+      (notification: PushNotificationSchema) => {
         alert('Push received: ' + JSON.stringify(notification));
       },
     );


### PR DESCRIPTION
Add step for installing the plugin, remove the capacitor/core imports and use the capacitor/push-notifications equivalent, replace `requestPermission` with `requestPermissions`