### PR TITLE
changed "npx @capacitor/cli plugin:generate" to "npx cap plugin:gener…

### DIFF
--- a/pages/docs/plugins/creating-plugins.md
+++ b/pages/docs/plugins/creating-plugins.md
@@ -14,7 +14,7 @@ Plugins in Capacitor enable JavaScript to interface directly with Native APIs.
 Capacitor comes with a Plugin generator to start new plugins quickly. To use it, run
 
 ```bash
-npx @capacitor/cli plugin:generate
+npx cap plugin:generate
 ```
 
 This starts a wizard prompting you for information about your new plugin. For example:


### PR DESCRIPTION
`npx  @capacitor/cli plugin:generate` does not work anymore. Running it will just create a `Gcli.txt` file with `rstcli.exe -I  1>Gcli.txt`

the file contains:
```
Could not get system information.

Could not get system info
```

`npx cap` works.