### PR TITLE
Updated Android activity/permission result steps

### DIFF
--- a/pages/docs/v3/updating/plugins/3-0.md
+++ b/pages/docs/v3/updating/plugins/3-0.md
@@ -21,16 +21,16 @@ During Capacitor 3 development, we will be evaluating this problem and creating 
 
 The `@NativePlugin` annotation is deprecated. We now recommend using the new `@CapacitorPlugin` annotation, which will allow for the [new permissions API](#adopting-the-new-permissions-api).
 
-The `name` and `requestCodes` attributes are the same. The `permissionRequestCode` attribute is removed. The `permissions` attribute will need to be replaced with list of `@Permission` annotations, each containing a list of manifest strings and their corresponding `alias`, which you can omit for now until the new permissions API is implemented in your plugin.
+The `name` attribute is the same. The `requestCodes` and `permissionRequestCode` attributes are removed. The `permissions` attribute will need to be replaced with list of `@Permission` annotations, each containing a list of manifest strings and their corresponding `alias`, which you can omit for now until the new permissions API is implemented in your plugin.
 
 ```diff-java
 -@NativePlugin(
 +@CapacitorPlugin(
      name = "FooBar",
-     requestCodes = {
-         FooBarPlugin.REQUEST_SOME_METHOD,
-         FooBarPlugin.REQUEST_SOME_OTHER_METHOD
-     },
+-    requestCodes = {
+-        FooBarPlugin.REQUEST_SOME_METHOD,
+-        FooBarPlugin.REQUEST_SOME_OTHER_METHOD
+-    },
 -    permissionRequestCode = FooBarPlugin.REQUEST_ALL_PERMISSIONS,
 -    permissions = { Manifest.permission.FOO, Manifest.permission.BAR }
 +    permissions = {
@@ -41,6 +41,33 @@ The `name` and `requestCodes` attributes are the same. The `permissionRequestCod
  public class FooBarPlugin extends Plugin {
      static final int REQUEST_SOME_METHOD = 10051;
      static final int REQUEST_SOME_OTHER_METHOD = 10052;
+```
+
+### Android request codes
+
+Capacitor 3.0 implements the AndroidX Activity Result API and removes manually defined request codes. Instead of providing a request code and overriding `handleOnActivityResult` or `handleRequestPermissionsResult`, plugins should provide callback methods using the `@ActivityCallback` or `@PermissionCallback` annotations. These callbacks can then be referenced when launching a new Activity or Permission request.
+
+```diff-java
+-static final int IMAGE_REQUEST = 10052;
+
+ @PluginMethod
+ public void chooseImage(PluginCall call) {
+     Intent intent = new Intent(Intent.ACTION_PICK);
+     intent.setType("image/*");
+-    startActivityForResult(call, intent, IMAGE_REQUEST);
++    startActivityForResult(call, intent, "chooseImageResult");
+ }
+
++@ActivityCallback
++private void chooseImageResult(PluginCall call, ActivityResult result) {
++    if (result.getResultCode() == Activity.RESULT_CANCELED) {
++        call.reject("Activity canceled");
++    } else {
++        Intent data = result.getData();
++        // do something with the result data
++        call.resolve("Success!");
++    }
++}
 ```
 
 ## iOS


### PR DESCRIPTION
Updates the Plugin update guide and Android guide related to the new Activity Result API changes: https://github.com/ionic-team/capacitor/pull/4127