### PR TITLE
Update config index.md to include cleartext option

### DIFF
--- a/pages/docs/config/index.md
+++ b/pages/docs/config/index.md
@@ -52,6 +52,8 @@ Here is a full example of available configuration options for `capacitor.config.
     // as it allows to run web APIs that require a secure context such as
     // navigator.geolocation and MediaDevices.getUserMedia.
     hostname: 'app',
+    // Starting with Android 9 (API level 28), cleartext support is disabled by default. Setting this option will allow cleartext traffic to prevent errors during local development on Android platforms. 
+    cleartext: true,
     // It is possible to configure the local scheme that is used. This can be useful
     // when migrating from cordova-plugin-ionic-webview, where the default scheme on iOS is ionic.
     iosScheme: 'ionic',


### PR DESCRIPTION
This proposal includes information about the cleartext property. Having this property in the server settings allows the developer to with the Android platform locally without the need of editing the generated AndroidManifest.