### PR TITLE
feat(push/local-notifications): Adding information about common notification issues 

### DIFF
--- a/pages/docs/v3/apis/local-notifications.md
+++ b/pages/docs/v3/apis/local-notifications.md
@@ -16,6 +16,10 @@ npm install @capacitor/local-notifications
 npx cap sync
 ```
 
+## Doze
+
+If the device has entered [Doze](https://developer.android.com/training/monitoring-device-state/doze-standby) mode, your application may have restricted capabilities.  If you need your notification to fire even during Doze, schedule your notification by using `allowWhileIdle: true`.  Make use of  `allowWhileIdle` judiciously, as these notifications [can only fire once per 9 minutes, per app.](https://developer.android.com/training/monitoring-device-state/doze-standby#assessing_your_app)
+
 ## API
 
 <docgen-index>

--- a/pages/docs/v3/apis/push-notifications.md
+++ b/pages/docs/v3/apis/push-notifications.md
@@ -74,6 +74,17 @@ An empty Array can be provided if none of the previous options are desired. `pus
   }
 }
 ```
+## Silent Push Notifications / Data-only Notifications
+
+This plugin does not support iOS Silent Push or Android / FCM Data-only notifications.  We recommend using native code solutions for handling these types of notifications.
+
+## Common Issues
+
+On Android, there are various system and app states that can affect the delivery of push notifications:
+
+* If the device has entered [Doze](https://developer.android.com/training/monitoring-device-state/doze-standby) mode, your application may have restricted capabilities.  To increase the chance of your notification being received, consider using [FCM high priority messages](https://firebase.google.com/docs/cloud-messaging/concept-options#setting-the-priority-of-a-message).
+* Be sure you are not sending a data-only or silent push notification.
+* There are differences in behavior between development and production.  Try testing your app outside of being launched by Android Studio.  Read more [here](https://stackoverflow.com/questions/48642423/firebase-push-notification-issue-in-android-when-app-is-closed-killed).
 
 ---
 

--- a/pages/docs/v3/apis/push-notifications.md
+++ b/pages/docs/v3/apis/push-notifications.md
@@ -78,6 +78,37 @@ An empty Array can be provided if none of the previous options are desired. `pus
 
 This plugin does not support iOS Silent Push or Android / FCM Data-only notifications.  We recommend using native code solutions for handling these types of notifications.
 
+#### iOS
+See [Pushing Background Updates to Your App](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app).
+
+#### Android
+See [Hanndling FCM Messages](https://firebase.google.com/docs/cloud-messaging/android/receive#handling_messages). 
+
+To handle data-only messages, install the Firebase Messaging libraries into your own app, and create a custom class that extends `FirebaseMessagingService` like below:
+
+```java
+public class AppMessagingService extends FirebaseMessagingService {
+    @Override
+    public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
+        super.onMessageReceived(remoteMessage);
+        PushNotificationsPlugin.sendRemoteMessage(remoteMessage);
+
+        if (!remoteMessage.getData().isEmpty()) {
+            // your code here
+            Log.d("FCM Push Notification", "Received a data-only push notification");
+            Log.d("FCM Push Notification", remoteMessage.getData().get("key_1"));
+        }
+    }
+    
+    @Override
+    public void onNewToken(@NonNull String s) {
+        super.onNewToken(s);
+        PushNotificationsPlugin.onNewToken(s);
+    }
+}
+```
+
+
 ## Common Issues
 
 On Android, there are various system and app states that can affect the delivery of push notifications:

--- a/pages/docs/v3/apis/push-notifications.md
+++ b/pages/docs/v3/apis/push-notifications.md
@@ -82,7 +82,7 @@ This plugin does not support iOS Silent Push or Android / FCM Data-only notifica
 See [Pushing Background Updates to Your App](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app).
 
 #### Android
-See [Hanndling FCM Messages](https://firebase.google.com/docs/cloud-messaging/android/receive#handling_messages). 
+See [Handling FCM Messages](https://firebase.google.com/docs/cloud-messaging/android/receive#handling_messages). 
 
 To handle data-only messages, install the Firebase Messaging libraries into your own app, and create a custom class that extends `FirebaseMessagingService` like below:
 


### PR DESCRIPTION
This PR adds notes for dealing with common issues related to handling push and local notifications:
- How to handle notifications during Doze
- Tips on testing the application during development

A note is also added to clarify that data-only / silent push notifications are NOT supported in this plugin.  Links to more documentation on how to enable silent push notifications on iOS are provided, as well as links and a code snippet on handling data-only notifications on Android.

closes: https://github.com/ionic-team/capacitor-plugins/issues/200, https://github.com/ionic-team/capacitor/issues/3500