### PR TITLE
Update iOS plugin upgrade guide

### DIFF
--- a/pages/docs/v3/updating/plugins/3-0.md
+++ b/pages/docs/v3/updating/plugins/3-0.md
@@ -72,16 +72,16 @@ Capacitor 3.0 implements the AndroidX Activity Result API and removes manually d
 
 ## iOS
 
-### Weak `bridge` Reference
+### Weak References
 
-The relationship between objects had to be updated in Capacitor 3 to fix memory leaks. The result is that a plugin's reference to the bridge is now `weak`, which in Swift means it is optional. Calling a method on the bridge is relatively unchanged except that it now requires optional chaining:
+The relationship between objects was updated in Capacitor 3 to fix memory leaks. The consequence is that a plugin's references to objects higher in the hierarchy are now `weak`, which in Swift means they are optional. You are most likely to encounter this change when accessing `bridge` but it also applies to other properties such as `webView`. Calling a method on the bridge is relatively unchanged except that it now requires optional chaining:
 
 ```diff-swift
 -bridge.presentVC(myViewController, animated: true, completion: nil)
 +bridge?.presentVC(myViewController, animated: true, completion: nil)
 ```
 
-The most common impact of this change is that now all return values from the bridge will be optional as well. [Handling and unwrapping optionals can require extra steps](https://docs.swift.org/swift-book/LanguageGuide/TheBasics.html).
+The biggest impact of this change is that all return values from the bridge will be optional as well. [Safely handling and unwrapping optionals can require extra steps](https://docs.swift.org/swift-book/LanguageGuide/TheBasics.html).
 
 ```swift
 if bridge?.isSimEnvironment {


### PR DESCRIPTION
Updating the iOS upgrade guide to more completely describe the change to weak references.

closes https://github.com/ionic-team/capacitor-site/issues/244