### PR TITLE
fix: Use relative urls instead of absolute

### DIFF
--- a/pages/docs/v3/apis/push-notifications.md
+++ b/pages/docs/v3/apis/push-notifications.md
@@ -18,7 +18,7 @@ npx cap sync
 
 ## iOS
 
-On iOS you must enable the Push Notifications capability. See [Setting Capabilities](https://capacitorjs.com/docs/v3/ios/configuration#setting-capabilities) for instructions on how to enable the capability.
+On iOS you must enable the Push Notifications capability. See [Setting Capabilities](../ios/configuration#setting-capabilities) for instructions on how to enable the capability.
 
 After enabling the Push Notifications capability, add the following to your app's `AppDelegate.swift`:
 

--- a/pages/docs/v3/updating/3-0.md
+++ b/pages/docs/v3/updating/3-0.md
@@ -363,17 +363,17 @@ A new `androidxCoordinatorLayoutVersion` variable is available, add it with valu
 
 The `androidxCoreVersion` can be updated to `1.3.2`.
 
-The `androidxMaterialVersion` variable was used by Action Sheet and Camera plugins, can be removed if not using them. If using them, check [Camera docs](https://capacitorjs.com/docs/v3/apis/camera#variables) and [Action Sheet docs](https://capacitorjs.com/docs/v3/apis/action-sheet#variables).
+The `androidxMaterialVersion` variable was used by Action Sheet and Camera plugins, can be removed if not using them. If using them, check [Camera docs](../apis/camera#variables) and [Action Sheet docs](../apis/action-sheet#variables).
 
-The `androidxBrowserVersion` variable was used by Browser plugin, can be removed if not using the plugin. If using the plugin, check the [docs](https://capacitorjs.com/docs/v3/apis/browser#variables).
+The `androidxBrowserVersion` variable was used by Browser plugin, can be removed if not using the plugin. If using the plugin, check the [docs](../apis/browser#variables).
 
 The `androidxLocalbroadcastmanagerVersion` variable can be removed.
 
-The `androidxExifInterfaceVersion` variable was used by Camera plugin, can be removed if not using the plugin. If using the plugin, check the [docs](https://capacitorjs.com/docs/v3/apis/camera#variables).
+The `androidxExifInterfaceVersion` variable was used by Camera plugin, can be removed if not using the plugin. If using the plugin, check the [docs](../apis/camera#variables).
 
-The `firebaseMessagingVersion` variable was used by Push Notifications plugin, can be removed if not using the plugin. If using the plugin, check the [docs](https://capacitorjs.com/docs/v3/apis/push-notifications#variables).
+The `firebaseMessagingVersion` variable was used by Push Notifications plugin, can be removed if not using the plugin. If using the plugin, check the [docs](../apis/push-notifications#variables).
 
-The `playServicesLocationVersion` variable was used by Geolocation plugin, can be removed if not using the plugin. If using the plugin, check the [docs](https://capacitorjs.com/docs/v3/apis/geolocation#variables).
+The `playServicesLocationVersion` variable was used by Geolocation plugin, can be removed if not using the plugin. If using the plugin, check the [docs](../apis/geolocation#variables).
 
 A new `androidxFragmentVersion` variable is available, add it with value `1.3.0`.
 


### PR DESCRIPTION
v3 is being appended in the middle of absolute urls for unknown reasons, switching to relative for now

closes https://github.com/ionic-team/capacitor-site/issues/246