### PR TITLE
Add StatusBar to recommended plugins to use with Ionic

### DIFF
--- a/pages/docs/v3/updating/3-0.md
+++ b/pages/docs/v3/updating/3-0.md
@@ -74,11 +74,12 @@ The Ionic Framework makes use of APIs in the following plugins:
 - [**Haptics**](/docs/apis/haptics)
 - [**Keyboard**](/docs/apis/keyboard)
 - [**StatusBar**](/docs/apis/status-bar)
+- [**SplashScreen**](/docs/apis/splash-screen)
 
 For best performance with Ionic Framework, you should make sure these plugins are installed even if you don't import them in your app:
 
 ```bash
-npm install @capacitor/app @capacitor/haptics @capacitor/keyboard @capacitor/status-bar
+npm install @capacitor/app @capacitor/haptics @capacitor/keyboard @capacitor/status-bar @capacitor/splash-screen
 ```
 
 ## Plugin Imports

--- a/pages/docs/v3/updating/3-0.md
+++ b/pages/docs/v3/updating/3-0.md
@@ -73,11 +73,12 @@ The Ionic Framework makes use of APIs in the following plugins:
 - [**App**](/docs/apis/app)
 - [**Haptics**](/docs/apis/haptics)
 - [**Keyboard**](/docs/apis/keyboard)
+- [**StatusBar**](/docs/apis/status-bar)
 
 For best performance with Ionic Framework, you should make sure these plugins are installed even if you don't import them in your app:
 
 ```bash
-npm install @capacitor/app @capacitor/haptics @capacitor/keyboard
+npm install @capacitor/app @capacitor/haptics @capacitor/keyboard @capacitor/status-bar
 ```
 
 ## Plugin Imports


### PR DESCRIPTION
Without the StatusBar plugin the "tap statusbar to scroll to top"-feature doesn't work on iOS in Capacitor 3.
This is expected native behaviour, so I propose to include the StatusBar-plugin in this list of recommended plugins to install with the use of Ionic.