### PR TITLE
Docs: Update building android using npx cap add android

### DIFF
--- a/pages/docs/basics/building-your-app.md
+++ b/pages/docs/basics/building-your-app.md
@@ -59,7 +59,7 @@ Once Xcode launches, you can build your app binary through the standard Xcode wo
 Android relies on Android Studio (or, optionally, the Android CLI tools) to build the app:
 
 ```bash
-npx cap copy android
+npx cap add android
 npx cap open android
 ```
 


### PR DESCRIPTION
- using "copy" throws [error] android" platform has not been created
- add runs successfully