### PR TITLE
Remove section on upgrade docs about importing capacitor/core

### DIFF
--- a/pages/docs/v3/updating/3-0.md
+++ b/pages/docs/v3/updating/3-0.md
@@ -125,21 +125,6 @@ While many of the plugin APIs remain the same to ease the migration process to C
 - **Filesystem**
   - `stat()` method now returns ctime and mtime timestamps in milliseconds on all platforms. Previously, iOS returned timestamps in seconds.
 
-## Importing `@capacitor/core`
-
-It is a good idea to add an import to `@capacitor/core` to the TypeScript file that bootstraps your app. This will include the Capacitor JavaScript bridge into your app.
-
-For example, in a React app, add the following import to `src/index.tsx`:
-
-```diff-typescript
-+import '@capacitor/core';
- import React from 'react';
- import ReactDOM from 'react-dom';
- import App from './App';
-
- ReactDOM.render(<App />, document.getElementById('root'));
-```
-
 ## iOS
 
 Capacitor 3 supports iOS 12+. Xcode 12+ is required. CocoaPods 1.8+ is recommended.


### PR DESCRIPTION
After the bridge refactor for the eventual `3.0.0-rc.1` release, this is no longer needed! The runtime should be imported as a side effect of loading a plugin

Fixes #217 