### PR TITLE
Add section to remove maven repository on Capacitor 2 upgrade guide

### DIFF
--- a/pages/docs/v3/updating/2-0.md
+++ b/pages/docs/v3/updating/2-0.md
@@ -228,3 +228,19 @@ In `android/app/src/main/res/xml/file_paths.xml` add `<cache-path name="my_cache
 ### Remove `launch_splash.xml`
 
 The `android/app/src/main/res/drawable/launch_splash.xml` file can be removed because it is no longer used.
+
+### Remove maven repository
+
+Capacitor is distributed on npm, so having the maven repository entry on `android/app/build.gradle` is no longer needed and can cause problems.
+Remove it from `repositories` section:
+
+```diff-groovy
+ repositories {
+-    maven {
+-        url "https://dl.bintray.com/ionic-team/capacitor"
+-    }
+     flatDir {
+         dirs '../capacitor-cordova-android-plugins/src/main/libs', 'libs'
+     }
+ }
+```


### PR DESCRIPTION
We missed this change on the Capacitor 2 upgrade guide and now with bintray sunset it could cause problems 

closes https://github.com/ionic-team/capacitor-site/issues/270