### PR TITLE
use saveCall instead of deprecated save on iOS plugin guide

### DIFF
--- a/pages/docs/v3/plugins/ios.md
+++ b/pages/docs/v3/plugins/ios.md
@@ -196,7 +196,7 @@ var locationManager: CLLocationManager?
 @objc override func requestPermissions(_ call: CAPPluginCall) {
     if let manager = locationManager, CLLocationManager.locationServicesEnabled() {
         if CLLocationManager.authorizationStatus() == .notDetermined {
-            call.save()
+            bridge?.saveCall(call)
             permissionCallID = call.callbackId
             manager.requestWhenInUseAuthorization()
         } else {


### PR DESCRIPTION
`call.save()` is deprecated, use the bridge method `bridge?.saveCall()`