### PR TITLE
Documenting different plugin method types

### DIFF
--- a/pages/docs/v3/core-apis/saving-calls.md
+++ b/pages/docs/v3/core-apis/saving-calls.md
@@ -14,7 +14,7 @@ Two reasons you might need a plugin call (`CAPPluginCall` on iOS or `PluginCall`
 1. To perform an asynchronous action, such as a network request.
 2. To provide repeated updates back to the JavaScript environment, such as streaming live geolocation data.
 
-These two reasons can overlap but there is an important distinction. Specifically, whether or not a call will need to return data more than once. The Capacitor bridge records each call that is made from JavaScript to native so that it can match the result to the correct code when the plugin returns it, and the default behavior is to erase this bookkeeping after `resolve()` or `reject()` is called once. But if your method is a callback that will `resolve()` multiple times, then there is an extra step involved.
+These two reasons can overlap but there is an important distinction. Specifically, whether or not a call will need to return data more than once. The Capacitor bridge records each call that is made from JavaScript to native so that it can match the result to the correct code when the plugin returns it, and the default behavior is to erase this bookkeeping after `resolve()` or `reject()` is called once. But if your method is a callback that will `resolve()` multiple times, then there is an extra step involved. More information about how to declare callbacks [can be found here.](/docs/plugins/method-types)
 
 ---
 
@@ -60,14 +60,4 @@ call.keepAlive = true
 call.setKeepAlive(true);
 ```
 
-Additionally for Android, use the `@PluginMethod` annotation `returnType` property to flag to inform the web app to keep the plugin call alive.
-
-```java
-@PluginMethod(returnType = PluginMethod.RETURN_CALLBACK)
-public void keepAliveExample(PluginCall call) {
-    savedCall = call;
-    call.setKeepAlive(true);
-}
-```
-
-If `keepAlive` is true, then `resolve()` can be called as many times as necessary and the result will be returned as expected. Setting this flag to true also means that the bridge will automatically call `saveCall()` for you during the first completion.
+If `keepAlive` is true, then `resolve()` can be called as many times as necessary and the result will be returned as expected. Setting this flag to true also means that the bridge will automatically call `saveCall()` for you after your method returns.

--- a/pages/docs/v3/plugins/README.md
+++ b/pages/docs/v3/plugins/README.md
@@ -36,3 +36,4 @@
   - [iOS Guide](ios.md)
   - [Android Guide](android.md)
   - [Web/PWA Guide](web.md)
+  - [Method Types](method-types.md)

--- a/pages/docs/v3/plugins/method-types.md
+++ b/pages/docs/v3/plugins/method-types.md
@@ -1,0 +1,92 @@
+---
+title: Method Types
+description: Capacitor Plugin Method Types
+contributors:
+  - ikeith
+---
+
+# Method Types
+
+When developing plugins, there are three different types of method signatures that can be used. All are asynchronous and promise-based.
+
+Let's consider a plugin definition that includes all three types:
+
+```typescript
+export type CallbackID = string;
+
+export interface MyData {
+  data: string;
+}
+
+export type MyPluginCallback = (message: MyData | null, err?: any) => void;
+
+export interface MyPlugin {
+  method1(): Promise<void>;
+  method2(): Promise<MyData>;
+  cmethod3(callback: MyPluginCallback): Promise<CallbackID>;
+}
+```
+
+## Void Return
+
+`method1()` is the simplest case that is expected to return no data. You can check the promise for an error but when it resolves the result is ignored.
+
+For android, you would annotate the method like this:
+
+```java
+@PluginMethod(returnType = PluginMethod.RETURN_NONE)
+public void method1(PluginCall call) {
+}
+```
+
+For iOS, you would declare the method this way in your plugin's `.m` file:
+
+```objc
+CAP_PLUGIN(MyPlugin, "MyPlugin",
+           CAP_PLUGIN_METHOD(method1, CAPPluginReturnNone);
+)
+```
+
+## Value Return
+
+`method2()` is the most common case, a promise that resolves with some value.
+
+For Android, this type is the default and specifying the return type is optional:
+
+```java
+@PluginMethod()
+public void method2(PluginCall call) {
+}
+```
+
+For iOS, you would declare the method this way in your plugin's `.m` file:
+
+```objc
+CAP_PLUGIN(MyPlugin, "MyPlugin",
+           CAP_PLUGIN_METHOD(method2, CAPPluginReturnPromise);
+)
+```
+
+## Callback
+
+`method3()` is the most complex type but also the least common in practice. It is used when your plugin needs to return data repeatedly such as when monitoring the device's location via geolocation.
+
+For android, you would annotate the method like this:
+
+```java
+@PluginMethod(returnType = PluginMethod.RETURN_CALLBACK)
+public void method3(PluginCall call) {
+}
+```
+
+For iOS, you would declare the method this way in your plugin's `.m` file:
+
+```objc
+CAP_PLUGIN(MyPlugin, "MyPlugin",
+           CAP_PLUGIN_METHOD(method3, CAPPluginReturnCallback);
+)
+```
+
+Callback methods take a function that will be invoked (potentially many times) from the native code and return a promise that will resolve with an identifier.
+
+On the native side, implementing a callback means you need to save the call so it can be invoked at a later time. [The specifics of how to handle that are discussed here.](/docs/core-apis/saving-calls)

--- a/pages/docs/v3/plugins/method-types.md
+++ b/pages/docs/v3/plugins/method-types.md
@@ -49,9 +49,9 @@ CAP_PLUGIN(MyPlugin, "MyPlugin",
 
 ## Value Return
 
-`method2()` is the most common case, a promise that resolves with some value.
+`method2()` is the most common case: A promise that resolves with some value.
 
-For Android, this type is the default and specifying the return type is optional:
+For Android, this method type is the default and specifying the return type is optional:
 
 ```java
 @PluginMethod()
@@ -69,7 +69,7 @@ CAP_PLUGIN(MyPlugin, "MyPlugin",
 
 ## Callback
 
-`method3()` is the most complex type but also the least common in practice. It is used when your plugin needs to return data repeatedly such as when monitoring the device's location via geolocation.
+`method3()` is the most complex type but also the least common in practice. It is used when your plugin needs to return data repeatedly, such as when monitoring the device's location via the geolocation API.
 
 For android, you would annotate the method like this:
 
@@ -89,4 +89,4 @@ CAP_PLUGIN(MyPlugin, "MyPlugin",
 
 Callback methods take a function that will be invoked (potentially many times) from the native code and return a promise that will resolve with an identifier.
 
-On the native side, implementing a callback means you need to save the call so it can be invoked at a later time. [The specifics of how to handle that are discussed here.](/docs/core-apis/saving-calls)
+On the native side, implementing a callback means you need to save the call so it can be invoked at a later time. The specifics of how to handle that [are discussed here.](/docs/core-apis/saving-calls)

--- a/pages/docs/v3/plugins/workflow.md
+++ b/pages/docs/v3/plugins/workflow.md
@@ -9,11 +9,11 @@ contributors:
 
 With the new plugin created, you can begin implementing functionality across a variety of platforms.
 
-## Implementing a New Function
+## Implementing a New Method
 
-To implement new functionality in your plugin, begin by defining the function's signature in the exported TypeScript interface for your plugin in `src/definitions.ts`.
+To implement new functionality in your plugin, begin by defining the method's signature in the exported TypeScript interface for your plugin in `src/definitions.ts`.
 
-In the example below, the `openMap()` function is added which takes a `latitude` and `longitude`. It is good practice to define interfaces for method parameters that can be imported and used in apps.
+In the example below, the `openMap()` method is added which takes a `latitude` and `longitude`. It is good practice to define interfaces for method parameters that can be imported and used in apps.
 
 ```diff-typescript
  export interface EchoPlugin {
@@ -36,7 +36,7 @@ Implement the web implementation in `src/web.ts`:
  } from './definitions';
 
  export class EchoPluginWeb extends WebPlugin implements EchoPlugin {
-   // other functions
+   // other methods
 
 +  async openMap(location: OpenMapOptions): Promise<void> {
 +    // logic here
@@ -79,6 +79,8 @@ Implement [iOS functionality](./ios) in `ios/Plugin/Plugin.swift`:
 
 > Remember to [register plugin methods](/docs/plugins/ios#export-to-capacitor) in your `.m` file.
 
+This example contains the most common type of method in plugins but details about all the supported types [can be found here.](/docs/plugins/method-types)
+
 ## Local Testing
 
 To test the plugin locally while developing it, link the plugin folder to your app using `npm install` with the path to your plugin.
@@ -120,11 +122,11 @@ The plugin template ships with a variety of scripts in `package.json`.
 
 ## Documentation
 
-To document plugin functionality, add [JSDoc](https://jsdoc.app) comment blocks to functions and properties.
+To document plugin functionality, add [JSDoc](https://jsdoc.app) comment blocks to methods and properties.
 
 > It is usually not necessary to include type information with the `@param` and `@returns` JSDoc tags in TypeScript files.
 
-Using our `openMap()` function as an example, open `src/definitions.ts` and start documenting!
+Using our `openMap()` method as an example, open `src/definitions.ts` and start documenting!
 
 ```diff-typescript
  export interface EchoPlugin {


### PR DESCRIPTION
This branch adds a new document describing the 3 different types of methods that a plugin can employ and how to declare them:
- Added `plugins/method-types.md`
- Added links to new document in several locations
- Updated `plugins/workflow.md` to use `method` instead of `function` for consistency since `method` is a more precise term in OOP and plugins are objects
- Removed method signature example in `core-apis/saving-calls.md` since it was redundant with the new document