### PR TITLE
Rename MyPlugin to EchoPlugin in some guides

### DIFF
--- a/pages/docs/v3/plugins/android.md
+++ b/pages/docs/v3/plugins/android.md
@@ -319,7 +319,7 @@ To remove a listener from the plugin object:
 ```typescript
 import { MyPlugin } from 'my-plugin';
 
-const myPluginEventListener = MyPlugin.addListener(
+const myPluginEventListener = await MyPlugin.addListener(
   'myPluginEvent',
   (info: any) => {
     console.log('myPluginEvent was fired');

--- a/pages/docs/v3/plugins/ios.md
+++ b/pages/docs/v3/plugins/ios.md
@@ -101,7 +101,7 @@ call.reject(error.localizedDescription, nil, error)
 To make sure Capacitor can see your plugin, you must do two things: export your Swift class to Objective-C, and register it
 using the provided Capacitor Objective-C Macros.
 
-To export your Swift class to Objective-C, make sure to add `@objc(MyPlugin)` above your Swift class, and add `@objc` before any plugin method, as shown above.
+To export your Swift class to Objective-C, make sure to add `@objc(EchoPlugin)` above your Swift class, and add `@objc` before any plugin method, as shown above.
 
 To register your plugin with Capacitor, you'll need to create a new Objective-C file (with a `.m` extension, _not_ `.h`!) corresponding to your plugin (such as `EchoPlugin.m`) and use the Capacitor macros to register the plugin, and each method that you will use. Important: you _must_ use the New File dialog in Xcode to do this. You'll then be prompted by Xcode to create a Bridging Header, which you _must_ do.
 
@@ -305,7 +305,7 @@ To remove a listener from the plugin object:
 ```typescript
 import { MyPlugin } from 'my-plugin';
 
-const myPluginEventListener = MyPlugin.addListener(
+const myPluginEventListener = await MyPlugin.addListener(
   'myPluginEvent',
   (info: any) => {
     console.log('myPluginEvent was fired');

--- a/pages/docs/v3/plugins/web.md
+++ b/pages/docs/v3/plugins/web.md
@@ -34,7 +34,7 @@ export class EchoPluginWeb extends WebPlugin implements EchoPlugin {
 }
 ```
 
-The `MyPlugin` interface defines the method signatures of your plugin. In TypeScript, we can ensure the web implementation (the `MyPluginWeb` class) correctly implements the interface.
+The `EchoPlugin` interface defines the method signatures of your plugin. In TypeScript, we can ensure the web implementation (the `EchoPluginWeb` class) correctly implements the interface.
 
 ## Permissions
 


### PR DESCRIPTION
On Web and iOS, the plugin guide was still using MyPlugin instead of EchoPlugin in some places. 
Also, addListener now needs an await.