### PR TITLE
Add status-bar to plugins required by ionic framework

### DIFF
--- a/pages/docs/v3/updating/3-0.md
+++ b/pages/docs/v3/updating/3-0.md
@@ -77,11 +77,12 @@ The Ionic Framework makes use of APIs in the following plugins:
 - [**App**](/docs/apis/app)
 - [**Haptics**](/docs/apis/haptics)
 - [**Keyboard**](/docs/apis/keyboard)
+- [**StatusBar**](/docs/apis/status-bar)
 
-For best performance with Ionic Framework, you should make sure these plugins are installed even if you don't import them in your app:
+For best user experience with Ionic Framework, you should make sure these plugins are installed even if you don't import them in your app:
 
 ```bash
-npm install @capacitor/app @capacitor/haptics @capacitor/keyboard
+npm install @capacitor/app @capacitor/haptics @capacitor/keyboard @capacitor/status-bar
 ```
 
 ## Plugin Imports


### PR DESCRIPTION
add status-bar plugin to the list of plugins that should be installed if using ionic framework

also change **performance** word to user **experience since**, since performance is confusing and not having the plugins would affect the user experience as some things won't work 

closes https://github.com/ionic-team/capacitor-site/pull/260
closes https://github.com/ionic-team/capacitor-site/issues/216