### PR TITLE
Remove minVersion from v3 config docs

### DIFF
--- a/pages/docs/v3/config/index.md
+++ b/pages/docs/v3/config/index.md
@@ -282,14 +282,6 @@ export interface CapacitorConfig {
     cordovaSwiftVersion?: string;
 
     /**
-     * Configure the minimum iOS version supported.
-     *
-     * @since 1.0.0
-     * @default 11.0
-     */
-    minVersion?: string;
-
-    /**
      * Configure custom linker flags for compiling Cordova plugins.
      *
      * @since 1.0.0


### PR DESCRIPTION
the config option was removed on Capacitor 3, so removing it from the docs

closes https://github.com/ionic-team/capacitor-site/issues/251