### PR TITLE
Use fixed Firebase version on v2 push guide

### DIFF
--- a/pages/docs/v2/guides/push-notifications-firebase.md
+++ b/pages/docs/v2/guides/push-notifications-firebase.md
@@ -305,8 +305,8 @@ We need to add Firebase to the CocoaPods provided for our App target. To do that
 target 'App' do
 capacitor_pods
 # Add your Pods here
-pod 'FirebaseCore' # Add this line
-pod 'Firebase/Messaging' # Add this line
+pod 'FirebaseCore', '7.11.0' # Add this line
+pod 'Firebase/Messaging', '7.11.0' # Add this line
 end
 ```
 
@@ -332,8 +332,8 @@ end
 target 'App' do
   capacitor_pods
   # Add your Pods here
-  pod 'FirebaseCore'
-  pod 'Firebase/Messaging'
+  pod 'FirebaseCore', '7.11.0'
+  pod 'Firebase/Messaging', '7.11.0'
 end
 ```
 


### PR DESCRIPTION
Firebase 8 removed support for FirebaseInstanceID, which this guide uses.

Fix the version to 7.11.0 as it was the latest 7.x released version.