### PR TITLE
Remove the USE_PUSH macro too

### DIFF
--- a/pages/docs/v3/updating/3-0.md
+++ b/pages/docs/v3/updating/3-0.md
@@ -258,7 +258,7 @@ In `ios/App/App/AppDelegate.swift`, update the following:
 
 ### Switch from hard-coded `CAPNotifications` to `NSNotification` extensions
 
-In `ios/App/App/AppDelegate.swift`, update the following:
+If using the push notifications feature, in `ios/App/App/AppDelegate.swift`, update the following:
 
 ```diff-swift
      override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -273,6 +273,8 @@ In `ios/App/App/AppDelegate.swift`, update the following:
          }
      }
 
+-    #if USE_PUSH
+
      func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
 -        NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidRegisterForRemoteNotificationsWithDeviceToken.name()), object: deviceToken)
 +        NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
@@ -282,6 +284,36 @@ In `ios/App/App/AppDelegate.swift`, update the following:
 -        NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidFailToRegisterForRemoteNotificationsWithError.name()), object: error)
 +        NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
      }
+
+-#endif
+```
+
+If not using push notifications you can remove the whole block
+
+```diff-swift
+     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+         super.touchesBegan(touches, with: event)
+
+         let statusBarRect = UIApplication.shared.statusBarFrame
+         guard let touchPoint = event?.allTouches?.first?.location(in: self.window) else { return }
+
+         if statusBarRect.contains(touchPoint) {
+-            NotificationCenter.default.post(CAPBridge.statusBarTappedNotification)
++            NotificationCenter.default.post(name: .capacitorStatusBarTapped, object: nil)
+         }
+     }
+
+-    #if USE_PUSH
+-
+-    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+-        NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidRegisterForRemoteNotificationsWithDeviceToken.name()), object: deviceToken)
+-    }
+-
+-    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+-        NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidFailToRegisterForRemoteNotificationsWithError.name()), object: error)
+-    }
+-
+-#endif
 ```
 
 ### Ignore `DerivedData`

--- a/pages/docs/v3/updating/3-0.md
+++ b/pages/docs/v3/updating/3-0.md
@@ -256,33 +256,20 @@ In `ios/App/App/AppDelegate.swift`, update the following:
      }
 ```
 
-### Switch from hard-coded `CAPNotifications` to `NSNotification` extensions
+### Remove USE_PUSH macro
 
 If using the push notifications feature, in `ios/App/App/AppDelegate.swift`, update the following:
 
 ```diff-swift
-     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-         super.touchesBegan(touches, with: event)
-
-         let statusBarRect = UIApplication.shared.statusBarFrame
-         guard let touchPoint = event?.allTouches?.first?.location(in: self.window) else { return }
-
-         if statusBarRect.contains(touchPoint) {
--            NotificationCenter.default.post(CAPBridge.statusBarTappedNotification)
-+            NotificationCenter.default.post(name: .capacitorStatusBarTapped, object: nil)
-         }
-     }
 
 -    #if USE_PUSH
 
      func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
--        NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidRegisterForRemoteNotificationsWithDeviceToken.name()), object: deviceToken)
-+        NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
+        NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidRegisterForRemoteNotificationsWithDeviceToken.name()), object: deviceToken)
      }
 
      func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
--        NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidFailToRegisterForRemoteNotificationsWithError.name()), object: error)
-+        NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+        NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidFailToRegisterForRemoteNotificationsWithError.name()), object: error)
      }
 
 -#endif
@@ -291,18 +278,6 @@ If using the push notifications feature, in `ios/App/App/AppDelegate.swift`, upd
 If not using push notifications you can remove the whole block
 
 ```diff-swift
-     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-         super.touchesBegan(touches, with: event)
-
-         let statusBarRect = UIApplication.shared.statusBarFrame
-         guard let touchPoint = event?.allTouches?.first?.location(in: self.window) else { return }
-
-         if statusBarRect.contains(touchPoint) {
--            NotificationCenter.default.post(CAPBridge.statusBarTappedNotification)
-+            NotificationCenter.default.post(name: .capacitorStatusBarTapped, object: nil)
-         }
-     }
-
 -    #if USE_PUSH
 -
 -    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
@@ -314,6 +289,34 @@ If not using push notifications you can remove the whole block
 -    }
 -
 -#endif
+```
+
+### Switch from hard-coded `CAPNotifications` to `NSNotification` extensions
+
+In `ios/App/App/AppDelegate.swift`, update the following:
+
+```diff-swift
+     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+         super.touchesBegan(touches, with: event)
+
+         let statusBarRect = UIApplication.shared.statusBarFrame
+         guard let touchPoint = event?.allTouches?.first?.location(in: self.window) else { return }
+
+         if statusBarRect.contains(touchPoint) {
+-            NotificationCenter.default.post(CAPBridge.statusBarTappedNotification)
++            NotificationCenter.default.post(name: .capacitorStatusBarTapped, object: nil)
+         }
+     }
+
+     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+-        NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidRegisterForRemoteNotificationsWithDeviceToken.name()), object: deviceToken)
++        NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
+     }
+
+     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+-        NotificationCenter.default.post(name: Notification.Name(CAPNotifications.DidFailToRegisterForRemoteNotificationsWithError.name()), object: error)
++        NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+     }
 ```
 
 ### Ignore `DerivedData`

--- a/pages/docs/v3/updating/3-0.md
+++ b/pages/docs/v3/updating/3-0.md
@@ -256,7 +256,7 @@ In `ios/App/App/AppDelegate.swift`, update the following:
      }
 ```
 
-### Remove USE_PUSH macro
+### Remove USE_PUSH compilation condition
 
 If using the push notifications feature, in `ios/App/App/AppDelegate.swift`, update the following:
 


### PR DESCRIPTION
Some users are keeping the `#if USE_PUSH` macro, which might make push not work, so document on the upgrade guide that it should be removed.