### PR TITLE
Typo: Wordpress must be WordPress

### DIFF
--- a/pages/docs/v3/guides/deep-links.md
+++ b/pages/docs/v3/guides/deep-links.md
@@ -341,9 +341,9 @@ Place the association files under `static/.well-known`. No additional steps are 
 
 Place the association files under `public/.well-known`. No additional steps are necessary; simply build then deploy the site.
 
-### Wordpress
+### WordPress
 
-See [here](https://devdactic.com/universal-links-ionic/) for Wordpress instructions.
+See [here](https://devdactic.com/universal-links-ionic/) for WordPress instructions.
 
 ## Verification
 


### PR DESCRIPTION
"Wordpress" is a not correct product name. "WordPress" is.

https://developer.wordpress.org/reference/functions/capital_p_dangit/