### PR TITLE
Use CLI version in plugin:generate command

### DIFF
--- a/pages/docs/v2/cli/plugin-generate.md
+++ b/pages/docs/v2/cli/plugin-generate.md
@@ -15,5 +15,5 @@ Create a new custom Capacitor plugin. This starts a wizard that prompts you for 
 npx cap plugin:generate
 
 # Capacitor CLI not installed
-npx @capacitor/cli plugin:generate
+npx @capacitor/cli@2.4.7 plugin:generate
 ```

--- a/pages/docs/v2/plugins/creating-plugins.md
+++ b/pages/docs/v2/plugins/creating-plugins.md
@@ -15,13 +15,13 @@ Plugins in Capacitor enable JavaScript to interface directly with Native APIs.
 Capacitor comes with a Plugin generator to start new plugins quickly. To use it, run
 
 ```bash
-npx @capacitor/cli plugin:generate
+npx @capacitor/cli@2.4.7 plugin:generate
 ```
 
 This starts a wizard prompting you for information about your new plugin. For example:
 
 ```bash
-npx @capacitor/cli plugin:generate
+npx @capacitor/cli@2.4.7 plugin:generate
 ✏️  Creating new Capacitor plugin
 ? Plugin NPM name (kebab-case): my-plugin
 ? Plugin id (domain-style syntax. ex: com.example.plugin) com.ionicframework.myplugin


### PR DESCRIPTION
CLI 3 removed the plugin:generate command, so on v2 docs specify a version so it uses CLI 2, where the command still works, instead of CLI 3