### PR TITLE
docs(): add note on installing plugins with ionic framework

### DIFF
--- a/pages/docs/v3/getting-started/with-ionic.md
+++ b/pages/docs/v3/getting-started/with-ionic.md
@@ -29,6 +29,19 @@ Install and initialize Capacitor with your app name and bundle ID:
 ionic integrations enable capacitor
 ```
 
+Ionic Framework makes use of the APIs in the following plugins:
+
+- [**App**](/docs/apis/app)
+- [**Haptics**](/docs/apis/haptics)
+- [**Keyboard**](/docs/apis/keyboard)
+- [**StatusBar**](/docs/apis/status-bar)
+
+For the best user experience, you should make sure these plugins are installed even if you don't import them in your app:
+
+```bash
+npm install @capacitor/app @capacitor/haptics @capacitor/keyboard @capacitor/status-bar
+```
+
 If your Ionic app uses Cordova, you will want to read the [Migrating from Cordova to Capacitor guide](/docs/cordova/migrating-from-cordova-to-capacitor) as well.
 
 ### Add Platforms


### PR DESCRIPTION
Some developers were not aware that Ionic Framework makes use of these plugins, so they did not install them. As a result, functionality like the hardware back button failed to work and developers did not know why.