### PR TITLE
docs: add note for when `cap` command is not found

### DIFF
--- a/pages/docs/v3/cordova/migrating-from-cordova-to-capacitor.md
+++ b/pages/docs/v3/cordova/migrating-from-cordova-to-capacitor.md
@@ -24,7 +24,7 @@ Initialize your app with Capacitor. Some of the information you will be prompted
 npx cap init
 ```
 
-> NOTE: If you do not have `@capcitor/cli` installed globally- you will need to add (@capacitor/cli) `npm i -D @capacitor/cli` to your project before running the above command.
+> NOTE: Run the above command after you have followed the guides above or you may get an error that `cap` is not found.
 
 ### Build your Web App
 

--- a/pages/docs/v3/cordova/migrating-from-cordova-to-capacitor.md
+++ b/pages/docs/v3/cordova/migrating-from-cordova-to-capacitor.md
@@ -24,6 +24,8 @@ Initialize your app with Capacitor. Some of the information you will be prompted
 npx cap init
 ```
 
+> NOTE: If you do not have `@capcitor/cli` installed globally- you will need to add (@capacitor/cli) `npm i -D @capacitor/cli` to your project before running the above command.
+
 ### Build your Web App
 
 You must build your web project at least once before adding any native platforms.


### PR DESCRIPTION
Experienced same issue as: https://github.com/ionic-team/capacitor/issues/2976
for when @capacitory/cli is not installed globally.

Observed fresh migration:
❯ npx cap init
command not found: cap

After:
❯ npm i -S @capacitor/core @capacitor/cli 
❯ npx cap init                           
[?] What is the name of your app?