### PR TITLE
Move  @capacitor/cli to devDependencies

### DIFF
--- a/pages/docs/v3/getting-started/index.md
+++ b/pages/docs/v3/getting-started/index.md
@@ -33,7 +33,8 @@ Capacitor was designed to drop into any modern JavaScript web app. Projects must
 In the root of your app, install Capacitor:
 
 ```bash
-npm install @capacitor/core @capacitor/cli
+npm install @capacitor/core
+npm install @capacitor/cli --save-dev
 ```
 
 Then, initialize Capacitor using the CLI questionnaire:


### PR DESCRIPTION
Inspired by this question 
https://github.com/ionic-team/capacitor/discussions/4606
I moved capacitor CLI to dev dependency

This has two advantages:
- Decrease prod package size
- Keeps project structure clean and uses npm like it was intended to use
