### PR TITLE
Add official link to iOS schemes limitations

### DIFF
--- a/pages/docs/v3/config/index.md
+++ b/pages/docs/v3/config/index.md
@@ -355,10 +355,10 @@ export interface CapacitorConfig {
     /**
      * Configure the local scheme on iOS.
      *
+     * [Can't be set to schemes that the WKWebView already handles, such as http or https](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/2875766-seturlschemehandler)
      * This can be useful when migrating from
      * [`cordova-plugin-ionic-webview`](https://github.com/ionic-team/cordova-plugin-ionic-webview),
      * where the default scheme on iOS is `ionic`.
-     * [Can't be set to http or https](https://github.com/ionic-team/capacitor/issues/2173#issuecomment-573820265)
      *
      * @since 1.2.0
      * @default capacitor


### PR DESCRIPTION
https://github.com/ionic-team/capacitor-site/pull/325 adds a link to a comment that makes it look like it's a limitation we add, but it's a WKWebView limitation, so change the link to the official Apple docs about the scheme limitations.

