### PR TITLE
Remove out of date line from getting started guide

### DIFF
--- a/pages/docs/v3/getting-started/index.md
+++ b/pages/docs/v3/getting-started/index.md
@@ -45,8 +45,6 @@ npx cap init
 
 The CLI will ask you a few questions, starting with your app name, and the package id you would like to use for your app.
 
-Last, it will ask what directory your web assets get built into. For Angular, this is `www`, React is `build`, and Vue is `dist`. If you don't know right now, you can update this value in the `capacitor.config.ts` file later.
-
 > The `npx cap` command is how Capacitor is executed locally on the command-line in your project. [Learn more about the Capacitor CLI](/docs/cli).
 
 ## Where to go next


### PR DESCRIPTION
The web dir was an option param, I think it never asked for it, or if it did, it was long long ago.
Also, in Capacitor 3, it tries to guess the folder, so this line makes no sense anymore.

