### PR TITLE
Add Plugin Not Implemented section to troubleshooting

### DIFF
--- a/pages/docs/v3/android/troubleshooting.md
+++ b/pages/docs/v3/android/troubleshooting.md
@@ -87,3 +87,17 @@ To do this, follow these steps:
 3. Remove the android directory: `rm -rf android/`
 4. Re-create the Android app from Capacitor: `npx cap add android`
 5. Copy your saved source files back into the project
+
+## Plugin Not Implemented
+
+On Android, this can happen if Capacitor doesn't find the plugins or can't inject its code into the WebView.
+
+First of all, make sure the plugin is installed and appears in the `package.json`.
+
+Then, run `npx cap sync android`.
+
+Finally, use the "Sync Project with Gradle Files" button in the top right of Android Studio (the icon looks like an elephant). This will re-sync your native Android code to include the new plugin code and should allow use of your new plugin.
+
+Also, if you are migrating from Capacitor 1 or 2, make sure you enabled the [automatic plugin loading](https://capacitorjs.com/docs/updating/3-0#switch-to-automatic-android-plugin-loading).
+
+If still getting the "Plugin not implemented" error, make sure you are not using service workers, that prevents Capacitor's and Plugins code from injecting. Or if you want to use them, you can use [this workaround](https://github.com/ionic-team/capacitor/issues/1655#issuecomment-579229390) for making the injection work.

--- a/pages/docs/v3/ios/troubleshooting.md
+++ b/pages/docs/v3/ios/troubleshooting.md
@@ -101,3 +101,15 @@ brew link --overwrite ruby
 Finally, make sure your `PATH` environment variable does not put `/usr/local/bin` after `$PATH`, but rather _before_ it.
 
 See [this StackOverflow issue](https://stackoverflow.com/questions/38993527/cocoapods-failed-to-connect-to-github-to-update-the-cocoapods-specs-specs-repo/48996424#48996424) for other possible solutions to this problem.
+
+## Plugin Not Implemented
+
+On iOS, this can happen if Capacitor doesn't find the plugins or can't inject its code into the WebView.
+
+First of all, make sure the plugin is installed and appears in the `package.json`.
+
+Then, run `npx cap sync ios`.
+
+Finally, check that the plugin is in `ios/App/Podfile`. If the plugin is not listed, make sure your Podfile looks like [this one](https://github.com/ionic-team/capacitor/blob/main/ios-template/App/Podfile) and run `npx cap sync` again.
+
+If still getting the "Plugin not implemented" error, make sure you don't have `WKAppBoundDomains` key in `ios/App/App/Info.plist`, that prevents Capacitor's and Plugins code from injecting. Remove the key if not needed, or if it can't be removed, add `limitsNavigationsToAppBoundDomains` to your capacitor config file with `true` value inside the `ios` object.


### PR DESCRIPTION
Common scenarios where the users get the "Plugin not implemented" error on both iOS and Android.

