### PR TITLE
fix: update dev server note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The Capacitor website (`capacitor-site/`) and documentation (`capacitor-site/pag
 1. Run `npm install`.
 1. Run `npm start` to build and deploy the website/docs to localhost.
 
-> Note: Content updated while the dev server is running won't be reflected locally. Stop the process, run `npm run site-structure`, then re-run `npm start`.
+> Note: Content updated while the dev server is running won't be reflected locally. Stop the process, then re-run `npm start`.
 
 ## Adding a new page to the sidebar
 


### PR DESCRIPTION
# What this PR includes

This pull request removes instruction to run the outdated `site-structure` command when running the dev server. To load new content, stop the process and re-run `npm start`. 