### PR TITLE
Document cordova's accessOrigins and staticPlugins properties

### DIFF
--- a/pages/docs/v3/config/index.md
+++ b/pages/docs/v3/config/index.md
@@ -430,11 +430,29 @@ export interface CapacitorConfig {
 
   cordova?: {
     /**
+     * Populates <access> tags in the config.xml with the origin set to
+     * the values entered here.
+     * If not provided, a single <access origin="*" /> tag gets included.
+     * It only has effect on a few Cordova plugins that respect the whitelist.
+     *
+     * @since 3.3.0
+     */
+    accessOrigins?: string[];
+
+    /**
      * Configure Cordova preferences.
      *
      * @since 1.3.0
      */
     preferences?: { [key: string]: string | undefined };
+
+    /**
+     * List of Cordova plugins that need to be static but are not
+     * already in the static plugin list.
+     *
+     * @since 3.3.0
+     */
+    staticPlugins?: string[];
   };
 
   /**


### PR DESCRIPTION
They were added in capacitor 3.3.0 but were not documented here