### PR TITLE
Include missing instructions for iOS Setup

### DIFF
--- a/pages/docs/v3/guides/push-notifications-firebase.md
+++ b/pages/docs/v3/guides/push-notifications-firebase.md
@@ -360,6 +360,18 @@ import Firebase
 FirebaseApp.configure()
 ```
 
+Then you need to add the following two methods to correctly handle the registration event:
+
+```swift
+func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+  NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
+}
+
+func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+  NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+}
+```
+
 Your completed `AppDelegate.swift` file should look something like this:
 
 ```swift
@@ -377,6 +389,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Override point for customization after application launch.
     FirebaseApp.configure()
     return true
+  }
+  
+  func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
+  }
+
+  func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+    NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
   }
 ```
 


### PR DESCRIPTION
The iOS part of the guide is missing a key required step that can be found on the Push notification API docs here https://capacitorjs.com/docs/apis/push-notifications#ios

Without the methods didRegisterForRemoteNotificationsWithDeviceToken & didFailToRegisterForRemoteNotificationsWithError the guide does not work on iOS