### PR TITLE
feat: add a plugin tutorial

### DIFF
--- a/pages/docs/v3/plugins/README.md
+++ b/pages/docs/v3/plugins/README.md
@@ -37,3 +37,12 @@
   - [Android Guide](android.md)
   - [Web/PWA Guide](web.md)
   - [Method Types](method-types.md)
+- Plugin Tutorial
+  - [Getting Started](tutorial/introduction.md)
+  - [Designing the Plugin API](tutorial/designing-the-plugin-api.md)
+  - [Using the Plugin API](tutorial/using-the-plugin-api.md)
+  - [Implementing for Web/PWA](tutorial/web-implementation.md)
+  - [Code Abstraction Patterns](tutorial/code-abstraction-patterns.md)
+  - [Implementing for iOS](tutorial/ios-implementation.md)
+  - [Implementing for Android](tutorial/android-implementation.md)
+  - [Packaging the Plugin](tutorial/packaging-the-plugin.md)

--- a/pages/docs/v3/plugins/tutorial/android-implementation.md
+++ b/pages/docs/v3/plugins/tutorial/android-implementation.md
@@ -1,0 +1,286 @@
+---
+title: Building a Capacitor Plugin
+description: Building a Capacitor Plugin - Implementing for Android
+contributors:
+  - eric-horodyski
+---
+
+# Implementing for Android
+
+Development for the plugin is nearly complete. All that’s left is the Android implementation!
+
+## Register the plugin with Capacitor
+
+> **Prerequisite:** Familiarize yourself with the <a href="https://capacitorjs.com/docs/android/custom-code" target="_blank">Capacitor Custom Native Android Code documentation</a> before continuing.
+
+Open up the Capacitor application’s Android project in Android Studio by running `npx cap open android`. Expand the **app** module and the **java** folder and right-click on your app’s Java package. Select **New -> Package** from the context menu and create a subpackage named **plugins**. Right-click the **plugins** package and repeat the preceding process to create a subpackage named **ScreenOrientation**.
+
+Next, right-click the **ScreenOrientation** package and add a new Java file by selecting **New -> Java File** from the context menu. Name this file `ScreenOrientationPlugin.java`. Repeat the process to create a new file named `ScreenOrientation.java`.
+
+Copy the following code into `ScreenOrientationPlugin.java`:
+
+```java
+package io.ionic.cap.plugin.plugins.ScreenOrientation;
+
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+@CapacitorPlugin(name = "ScreenOrientation")
+public class ScreenOrientationPlugin extends Plugin {
+
+   @PluginMethod()
+   public void orientation(PluginCall call) {
+       call.resolve();
+   }
+
+   @PluginMethod()
+   public void lock(PluginCall call) {
+       call.resolve();
+   }
+
+   @PluginMethod()
+   public void unlock(PluginCall call) {
+       call.resolve();
+   }
+}
+```
+
+Register the plugin class within the project’s MainActivity to bridge between Java and JavaScript. Open `MainActivity.java` and add an `onCreate()` method where we can register the plugin:
+
+```java
+package io.ionic.cap.plugin;
+
+import android.os.Bundle;
+import com.getcapacitor.BridgeActivity;
+import io.ionic.cap.plugin.plugins.ScreenOrientation.ScreenOrientationPlugin;
+
+public class MainActivity extends BridgeActivity {
+   @Override
+   public void onCreate(Bundle savedInstanceState) {
+       super.onCreate(savedInstanceState);
+       registerPlugin(ScreenOrientationPlugin.class);
+   }
+}
+```
+
+## Getting the current screen orientation
+
+Like iOS, we will tackle getting the current screen orientation first. Open `ScreenOrientation.java` to set up the class and write a method to get the current orientation:
+
+```java
+package io.ionic.cap.plugin.plugins.ScreenOrientation;
+
+import android.view.Surface;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class ScreenOrientation {
+   private AppCompatActivity activity;
+
+   public ScreenOrientation(AppCompatActivity activity) {
+       this.activity = activity;
+   }
+
+   public String getCurrentOrientationType() {
+       int rotation = activity.getWindowManager().getDefaultDisplay().getRotation();
+       return fromRotationToOrientationType(rotation);
+   }
+
+   private String fromRotationToOrientationType(int rotation) {
+       switch (rotation) {
+           case Surface.ROTATION_90:
+               return "landscape-primary";
+           case Surface.ROTATION_180:
+               return "portrait-secondary";
+           case Surface.ROTATION_270:
+               return "landscape-secondary";
+           default:
+               return "portrait-primary";
+       }
+   }
+}
+```
+
+Next, wire up the `orientation` method in `ScreenOrientationPlugin.java` to call the implementation class’s method:
+
+```java
+package io.ionic.cap.plugins.ScreenOrientation;
+
+import com.getcapacitor.JSObject;
+/* Remaining imports omitted for brevity */
+
+@CapacitorPlugin(name = "ScreenOrientation")
+public class ScreenOrientationPlugin extends Plugin {
+
+   private ScreenOrientation implementation;
+
+   @Override
+   public void load() {
+       implementation = new ScreenOrientation(getActivity());
+   }
+
+   @PluginMethod()
+   public void orientation(PluginCall call) {
+       JSObject ret = new JSObject();
+       String type = implementation.getCurrentOrientationType();
+       ret.put("type", type);
+       call.resolve(ret);
+   }
+
+   /* Remaining code omitted for brevity */
+}
+```
+
+The `load()` method is the proper place to initialize the `ScreenOrientation` class instance with the Capacitor bridge object.
+
+Run the app from within Android Studio, either on an actual device or an Android emulator. Open **Logcat** and you should see the call logged:
+
+```bash
+V/Capacitor/Plugin: To native (Capacitor plugin): callbackId: 89582874, pluginId: ScreenOrientation, methodName: orientation
+```
+
+> **Note:** The exact value of the logs will be different for you. In this example, `89582874` is an arbitrary ID assigned to the method call made from the plugin.
+
+## Listening for screen orientation changes
+
+Android considers the rotation of a device a runtime configuration change, so we need a way for our plugin to <a href="https://developer.android.com/guide/topics/resources/runtime-changes" target="_blank">handle configuration changes</a>.
+
+Capacitor provides an overridable method, `handleOnConfigurationChanged()`, that can be used to respond to runtime configuration changes.
+
+First add the following import to the `ScreenOrientationPlugin` class:
+
+```java
+import android.content.res.Configuration;
+```
+
+Then add the following methods to the `ScreenOrientationPlugin` class:
+
+```java
+@Override
+public void handleOnConfigurationChanged(Configuration newConfig) {
+   super.handleOnConfigurationChanged(newConfig);
+   this.onOrientationChanged();
+}
+
+private void onOrientationChanged() {
+   JSObject ret = new JSObject();
+   String type = implementation.getCurrentOrientationType();
+   ret.put("type", type);
+   notifyListeners("screenOrientationChange", ret);
+}
+```
+
+When Android notifies an application of a configuration change, it returns the entire new configuration object, presenting two challenges:
+
+1. How do we make sure we only notify listeners when the orientation changes?
+2. How do we know that the configuration change was due to an orientation change?
+
+We will need the plugin to keep track of the previous `newConfig.orientation` value to compare against additional configuration changes to address those challenges.
+
+Make the following additions to the `ScreenOrientation` class:
+
+```java
+@Nullable private int configOrientation;
+
+public boolean hasOrientationChanged(int orientation) {
+    if (orientation == configOrientation) {
+        return false;
+    } else {
+        this.configOrientation = orientation;
+        return true;
+    }
+}
+```
+
+Don't forget to import `androidx.annotation.Nullable` to `ScreenOrientation.java`.
+
+Then update the `handleOnConfigurationChanged()` method in `ScreenOrientationPlugin.java`:
+
+```java
+@Override
+public void handleOnConfigurationChanged(Configuration newConfig) {
+   super.handleOnConfigurationChanged(newConfig);
+   if(implementation.hasOrientationChanged(newConfig.orientation)) {
+       this.onOrientationChanged();
+   }
+}
+```
+
+Now, the plugin will only notify listeners if-and-only-if runtime configuration changes pertain to the orientation changing.
+
+## Locking and unlocking the screen orientation
+
+As we saw with the iOS implementation, we’ll need a helper method to map the JavaScript OrientationType into a corresponding native enumeration value. For Android, we’ll map an OrientationType to an ActivityInfo enumeration value. Add the following method to the `ScreenOrientation` class:
+
+```java
+private int fromOrientationTypeToEnum(String orientationType) {
+   switch (orientationType) {
+       case "landscape-primary":
+           return ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
+       case "landscape-secondary":
+           return ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE;
+       case "portrait-secondary":
+           return ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT;
+       default:
+           // Case: portrait-primary
+           return ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+   }
+}
+```
+
+Make sure to import `android.content.pm.ActivityInfo` to `ScreenOrientation.java`.
+
+Next, add a `lock()` method to the `ScreenOrientation` class:
+
+```java
+public void lock(String orientationType) {
+   int orientationEnum = fromOrientationTypeToEnum(orientationType);
+   activity.setRequestedOrientation(orientationEnum);
+}
+```
+
+This method needs to get called from the `ScreenOrientationPlugin` class:
+
+```java
+@PluginMethod()
+public void lock(PluginCall call) {
+   String orientationType = call.getString("orientation");
+   if(orientationType == null) {
+       call.reject("Input option 'orientation' must be provided.");
+       return;
+   }
+   implementation.lock(orientationType);
+   call.resolve();
+}
+```
+
+Note, we guard against calls to the `lock()` method that do not supply the `orientation` input parameter.
+
+To unlock the screen orientation, we set the activity’s orientation type to the unspecified enumeration value. Add the following method to the `ScreenOrientation` class:
+
+```java
+public void unlock() {
+   activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+}
+```
+
+Then call the implementation method from the `ScreenOrientationPlugin` class:
+
+```java
+@PluginMethod()
+public void unlock(PluginCall call) {
+   implementation.unlock();
+   call.resolve();
+}
+```
+
+## Give it a test drive!
+
+In Android Studio, run the app on either a device or an emulator. Pressing the “Rotate My Device” button will rotate the screen orientation into landscape mode, and if you rotate further, you will see that the screen orientation is locked. Pressing “Confirm Signature“ will unlock the screen orientation.
+
+> **Note:** Ensure that you have the **Auto-rotate** device setting set to **on** before testing the plugin out; otherwise, it won’t function.
+
+Congratulations, you’ve built a Capacitor plugin that works for web, iOS, and Android! 👏 👏 👏
+
+As it stands, the `ScreenOrientation` plugin is a local plugin; only this application can use it. And that’s OK! Many times you’ll only want a plugin used only within a particular app. However, if you would like to reuse a plugin in multiple apps, we’ll see how to do that in the final step: packaging the plugin.

--- a/pages/docs/v3/plugins/tutorial/code-abstraction-patterns.md
+++ b/pages/docs/v3/plugins/tutorial/code-abstraction-patterns.md
@@ -1,0 +1,81 @@
+---
+title: Building a Capacitor Plugin
+description: Building a Capacitor Plugin - Code Abstraction Patterns
+contributors:
+  - eric-horodyski
+---
+
+# Capacitor Plugin Abstraction Patterns
+
+Plugins that get built for Capacitor can vary in complexity. Let’s use the <a href="https://capacitorjs.com/docs/plugins" target="_blank">Official Capacitor Plugins</a> as an example: the Android implementation of the <a href="https://github.com/ionic-team/capacitor-plugins/blob/main/toast/android/src/main/java/com/capacitorjs/plugins/toast/Toast.java" target="_blank">Toast plugin</a> is simple, while <a href="https://github.com/ionic-team/capacitor-plugins/tree/main/push-notifications/android/src/main/java/com/capacitorjs/plugins/pushnotifications" target="_blank">Push Notifications</a> is quite complex with multiple files.
+
+Depending on the plugin’s complexity and requirements, it would not be a stretch to scope the work required to build a plugin as its own software project, specifically if implementing requirements vary between iOS and Android.
+
+That said, a refresher on design patterns and a review of standard Capacitor plugin code abstractions are in order.
+
+## Design Patterns 101
+
+Design patterns are general, reusable solutions to common problems in software design. Design patterns aren’t programmatic solutions to problems; instead, they are guides or blueprints on abstracting code to solve recurring problems.
+
+You have most likely used design patterns even if you aren’t aware of them. Angular heavily relies on the Dependency Injection and Singleton patterns. React uses the Mediator and State patterns. Push notifications use the Observer pattern.
+
+As a developer, you should feel empowered to use the library of design patterns to craft code abstractions that work for your Capacitor plugins.
+
+Some good resources that describe and provide examples of design patterns are:
+
+- <a href="https://www.oreilly.com/library/view/head-first-design/0596007124/" target="_blank">Head First Design Patterns (O'Reilly Publishing)</a>
+- <a href="https://refactoring.guru/design-patterns" target="_blank">Design Patterns (Refactoring Guru)</a>
+
+> Personally speaking, I keep a copy of _Head First Design Patterns_ to leaf through in the planning phases of projects and browse _Refactoring Guru_ when I’m heads-down writing code.
+
+## Patterns in the wild
+
+If you look through the source code of enough Capacitor plugins, you will see that specific design patterns are popular with Capacitor plugin developers.
+
+**Bridge Design Pattern**
+
+The Bridge design pattern splits the abstraction from the implementation of code. It is a design mechanism that encapsulates an implementation class inside of an interface class.
+
+The Official Capacitor plugins heavily use the Bridge pattern, evidenced by this example from the Device plugin:
+
+```swift
+@objc func getLanguageCode(_ call: CAPPluginCall) {
+    let code = implementation.getLanguageCode()
+    call.resolve([ "value": code ])
+}
+```
+
+Why does this design pattern fit so well for Capacitor plugins?
+
+- You can focus on high-level logic in the abstraction and on platform details in the implementation.
+- You hide implementation details from the client.
+- You can introduce new implementations independently from each other.
+- You can create platform-independent classes and implementations.
+
+**Facade Design Pattern**
+
+The Facade design pattern provides a simple interface to a complex subsystem containing many moving parts. It may not expose all the functionality of the subsystem. However, it does expose the features that clients care about.
+
+Some of the more complex Capacitor Official plugins use the Facade pattern, including the Local Notifications plugin:
+
+```java
+@Override
+public void load() {
+    super.load();
+    notificationStorage = new NotificationStorage(getContext());
+    manager = new LocalNotificationManager( … );
+    manager.createNotificationChannel();
+    notificationChannelManager = new NotificationChannelManager(getActivity();
+    staticBridge = this.bridge;
+}
+```
+
+Why does this design pattern fit well for Capacitor plugins?
+
+- You can isolate your code from the complexity of a subsystem.
+- You can protect the client code from any changes in the subsystem code.
+- You can structure a subsystem into layers.
+
+## What will the screen orientation plugin use?
+
+The `ScreenOrientation` plugin will use the Bridge design pattern. While we haven’t addressed the underlying iOS and Android APIs required to perform the actions the plugin requires, implementing our plugin’s API is straightforward and relatively simple, as you will see, starting with the next step: the iOS implementation.

--- a/pages/docs/v3/plugins/tutorial/designing-the-plugin-api.md
+++ b/pages/docs/v3/plugins/tutorial/designing-the-plugin-api.md
@@ -1,0 +1,98 @@
+---
+title: Building a Capacitor Plugin
+description: Building a Capacitor Plugin - Designing the Plugin API
+contributors:
+  - eric-horodyski
+---
+
+# Designing the Plugin API
+
+The first - and arguably most important - step when building a Capacitor plugin is to design the API. The API is the contract we will adhere to when writing each platform’s specific implementation.
+
+We can define the plugin API using TypeScript; it will serve as our contract when implementing and provides the niceties that come with TypeScript, such as code completion and type checking.
+
+## Wait, do you even need a plugin for that?
+
+Believe it or not, modern web browsers can do many things that we think of as “native functionality,” such as checking battery status, speech recognition, and, yes, screen orientation. It’s not uncommon when building Web Native applications to see functionality that once required plugins to access are now available as Web APIs.
+
+> Before building a plugin for a particular feature, we recommend checking out sites such as <a href="https://whatwebcando.today/" target="_blank">What Web Can Do Today</a> to see if the functionality you are looking for is already available as a Web API.
+
+If screen orientation already has a Web API, why would we go out of our way to build one? Taking a look at the <a href="https://whatwebcando.today/screen-orientation.html" target="_blank">Screen Orientation Web API</a> we can see that iOS does not implement the API (as of this writing), which means we will need to provide the implementation ourselves. As it relates to Android, we could just use the Screen Orientation Web API when our app runs on the Android platform - but we will implement screen orientation functionality natively for educational purposes.
+
+## Defining the ScreenOrientation API
+
+We might not be able to use the Screen Orientation Web API outright, but we can model our plugin’s API against it:
+
+| Method Name        | Input Parameters                            | Return Value                                           |
+| ------------------ | ------------------------------------------- | ------------------------------------------------------ |
+| orientation        |                                             | `Promise<{ type: OrientationType }>`                   |
+| lock               | `{ orientation: OrientationLockType }`      | `Promise<void>`                                        |
+| unlock             |                                             | `Promise<void>`                                        |
+| addListener        | `(orientation: { type: OrientationType }) ` | `Promise<PluginListenerHandle> & PluginListenerHandle` |
+| removeAllListeners |                                             | `Promise<void>`                                        |
+
+There is an added advantage here; we can use the `OrientationType` and `OrientationLockType` types available through TypeScript’s existing DOM typings.
+
+Let's set up a directory to hold our plugin API. Create a new subfolder `src/plugins/screen-orientation` and add the following files within:
+
+- `definitions.ts`
+- `index.ts`
+
+Populate `definitions.ts` with the following code:
+
+```typescript
+import type { PluginListenerHandle } from '@capacitor/core';
+
+export interface ScreenOrientationPlugin {
+  /**
+   * Returns the screen's current orientation.
+   */
+  orientation(): Promise<{ type: OrientationType }>;
+
+  /**
+   * Locks the screen orientation.
+   */
+  lock(opts: { orientation: OrientationLockType }): Promise<void>;
+
+  /**
+   * Unlocks the screen's orientation.
+   */
+  unlock(): Promise<void>;
+
+  /**
+   * Listens for screen orientation changes.
+   */
+  addListener(
+    eventName: 'screenOrientationChange',
+    listenerFunc: (orientation: { type: OrientationType }) => void,
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
+
+  /**
+   * Removes all listeners
+   */
+  removeAllListeners(): Promise<void>;
+}
+```
+
+## Registering the ScreenOrientation plugin
+
+In order to use the plugin in the Capacitor application, we need to register it using the `registerPlugin()` module exported from `@capacitor/core`.
+
+Populate `index.ts` with the following code:
+
+```typescript
+import { registerPlugin } from '@capacitor/core';
+
+import type { ScreenOrientationPlugin } from './definitions';
+
+const ScreenOrientation = registerPlugin<ScreenOrientationPlugin>(
+  'ScreenOrientation',
+);
+
+export * from './definitions';
+export { ScreenOrientation };
+```
+
+The code above creates an object linked to our plugin's implementation code.
+
+Designing the API is complete; let’s build a user interface that will call it. In doing so, we will make testing easier as we implement each platform integration. Our next step: using the plugin API.

--- a/pages/docs/v3/plugins/tutorial/introduction.md
+++ b/pages/docs/v3/plugins/tutorial/introduction.md
@@ -1,0 +1,46 @@
+---
+title: Building a Capacitor Plugin
+description: Building a Capacitor Plugin
+contributors:
+  - eric-horodyski
+---
+
+# Building a Capacitor Plugin
+
+Capacitor provides a comprehensive Plugin API to use when adding native functionality to a Capacitor app.
+
+There are two types of Capacitor plugins: a _local plugin_ is custom native code isolated to a particular Capacitor application, residing within the native projects committed as part of source control. A _global plugin_ is a published npm package that developers can add to any Capacitor application.
+
+In this tutorial, we will start with a blank Capacitor application and add native code to it to build a local plugin. Then we will package it up into a global plugin, ready to be published.
+
+## So, what are we going to build?
+
+Pretend that you work for a delivery carrier, and the application you wrote lets drivers obtain signatures from customers, confirming they have received their deliveries. The legal team noticed customer signatures were of poor quality because drivers had customers sign in portrait mode. They’ve tasked you to force the app into landscape mode when capturing signatures.
+
+The plugin we build will implement **screen orientation** features to accommodate this request:
+
+- The device’s current **orientation** will be detected, with differing UIs for portrait and landscape mode.
+- Users will be given the option to rotate and **lock** their screen orientation to landscape mode.
+- After a signature has been confirmed, the app will **unlock** screen orientation rotation.
+
+For this tutorial, we will mock up a signature pad but only build out screen orientation functionality.
+
+This `ScreenOrientation` plugin will work across the web, iOS, and Android platforms.
+
+## Getting started
+
+Clone <a href="https://github.com/ionic-enterprise/capacitor-plugin-tutorial" target="_blank">this repository</a> and check out the `start` branch. Run `npm install` at the root of the project.
+
+> This tutorial uses `@ionic/react` to build the user interface. If you are not familiar with React or the Ionic Framework, that’s OK! The concepts covered apply to Capacitor apps using any TypeScript-enabled web framework.
+
+Add both the iOS and Android platforms to the Capacitor app:
+
+```bash
+npm run build
+npm install @capacitor/ios @capacitor/android
+npx cap add ios
+npx cap add android
+npx cap sync
+```
+
+Now that we have a Capacitor app in place with native platforms added, we’re ready to move on to the first step of building a plugin: designing the API.

--- a/pages/docs/v3/plugins/tutorial/ios-implementation.md
+++ b/pages/docs/v3/plugins/tutorial/ios-implementation.md
@@ -1,0 +1,284 @@
+---
+title: Building a Capacitor Plugin
+description: Building a Capacitor Plugin - Implementing for iOS
+contributors:
+  - eric-horodyski
+---
+
+# Implementing for iOS
+
+The decision to implement iOS before Android is arbitrary - in all honesty, you could have written the Android implementation first, then iOS, then web. Or any combination of the three. It just so happens that this tutorial implements iOS before Android.
+
+You may want to implement the web first because it sits closer to the plugin’s API definition. If any tweaks need to be made to the API, it’s far easier to uncover them while working in the web layer.
+
+## Register the plugin with Capacitor
+
+> **Prerequisite:** Familiarize yourself with the <a href="https://capacitorjs.com/docs/ios/custom-code" target="_blank">Capacitor Custom Native iOS Code documentation</a> before continuing.
+
+Open up the Capacitor application’s iOS project in Xcode by running `npx cap open ios`. Right-click the **App** group (under the **App** target) and select **New Group** from the context menu. Name this new group **plugins**. Add a new group to **plugins** and name it **ScreenOrientation**.
+
+Once complete, you'll have a path `/App/App/plugins/ScreenOrientation/`. Add the following files by right-clicking the **ScreenOrientation** group and selecting **New File…** from the context menu:
+
+`ScreenOrientation.swift`
+`ScreenOrientationPlugin.swift`
+`ScreenOrientationPlugin.m`
+
+If prompted by Xcode to create a Bridging Header, click **Create Bridging Header**.
+
+Copy the following code into `ScreenOrientationPlugin.m`:
+
+```objc
+#import <Foundation/Foundation.h>
+#import <Capacitor/Capacitor.h>
+
+CAP_PLUGIN(ScreenOrientationPlugin, "ScreenOrientation",
+  CAP_PLUGIN_METHOD(orientation, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(lock, CAPPluginReturnPromise);
+  CAP_PLUGIN_METHOD(unlock, CAPPluginReturnPromise);
+)
+```
+
+These Objective-C macros register the plugin with Capacitor, making `ScreenOrientationPlugin` and its methods available to JavaScript.
+
+Copy the following code into `ScreenOrientationPlugin.swift`:
+
+```swift
+import Foundation
+import Capacitor
+
+@objc(ScreenOrientationPlugin)
+public class ScreenOrientationPlugin: CAPPlugin {
+
+  @objc public func orientation(_ call: CAPPluginCall) {
+    call.resolve()
+  }
+
+  @objc public func lock(_ call: CAPPluginCall) {
+    call.resolve()
+  }
+
+  @objc public func unlock(_ call: CAPPluginCall) {
+    call.resolve();
+  }
+}
+```
+
+Note the use of `@objc` decorators; these are required to make sure Capacitor can see the class and its methods at runtime.
+
+## Getting the current screen orientation
+
+Let’s tackle the task of getting the current screen orientation first. Open up `ScreenOrientation.swift` to set up the class and write a method to get the current orientation:
+
+```swift
+import Foundation
+import UIKit
+
+public class ScreenOrientation: NSObject {
+
+  public func getCurrentOrientationType() -> String {
+    let currentOrientation: UIDeviceOrientation = UIDevice.current.orientation
+    return fromDeviceOrientationToOrientationType(currentOrientation)
+  }
+
+  private func fromDeviceOrientationToOrientationType(_ orientation: UIDeviceOrientation) -> String {
+    switch orientation {
+    case .landscapeLeft:
+      return "landscape-primary"
+    case .landscapeRight:
+      return "landscape-secondary"
+    case .portraitUpsideDown:
+      return "portrait-secondary"
+    default:
+      // Case: portrait
+      return "portrait-primary"
+    }
+  }
+
+}
+```
+
+Next, wire up the `orientation` method in `ScreenOrientationPlugin.swift` to call the implementation class’s method:
+
+```Swift
+@objc(ScreenOrientationPlugin)
+public class ScreenOrientationPlugin: CAPPlugin {
+
+  private let implementation = ScreenOrientation()
+
+  @objc public func orientation(_ call: CAPPluginCall) {
+    let orientationType = implementation.getCurrentOrientationType();
+    call.resolve(["type": orientationType])
+  }
+
+  /* Remaining code omitted for brevity */
+}
+```
+
+Go ahead and run the app from Xcode, either on an actual device or an iOS simulator. Once it finishes loading, you should see the following logs printed to the console:
+
+```bash
+⚡️  To Native ->  ScreenOrientation orientation 115962915
+⚡️  TO JS {"type":"portrait-primary"}
+```
+
+> **Note:** The exact value of the logs will be different for you. In this example, `115962915` is an arbitrary ID assigned to the method call made from the plugin.
+
+You’ve successfully bridged native iOS code to the web application! 🎉
+
+## Listening for screen orientation changes
+
+iOS will let us know when a user rotates their device through the <a href="https://developer.apple.com/documentation/foundation/notificationcenter" target="_blank">NotificationCenter</a>, when UIDevice fires the `orientationDidChangeNotification` event.
+
+The `load()` method is the proper place to register an observer for this event. Likewise, the `deinit()` method is the appropriate place to remove the observer.
+
+Within the observer registration, we need to provide a method to return the changed orientation to our plugin’s listeners listening for the `screenOrientationChange` event we defined as part of our plugin’s API. We can reuse the `getCurrentOrientationType()` method to obtain the changed screen orientation.
+
+Add the following methods to the `ScreenOrientationPlugin` class:
+
+```swift
+override public func load() {
+  NotificationCenter.default.addObserver(
+    self,
+    selector: #selector(self.orientationDidChange),
+    name: UIDevice.orientationDidChangeNotification,
+    object: nil)
+}
+
+deinit {
+  NotificationCenter.default.removeObserver(self)
+}
+
+@objc private func orientationDidChange() {
+  // Ignore changes in orientation if unknown, face up, or face down
+  if(UIDevice.current.orientation.isValidInterfaceOrientation) {
+    let orientation = implementation.getCurrentOrientationType()
+    notifyListeners("screenOrientationChange", data: ["type": orientation])
+  }
+}
+```
+
+iOS will detect changes in orientation in three dimensions. As the code comment mentions, we’ll ignore notifying listeners when orientation changes don’t reference landscape or portrait orientations.
+
+## Locking and unlocking the screen orientation
+
+iOS doesn’t exactly provide a mechanism to “lock” or “unlock” a screen orientation. Instead, it allows you to set which orientations are allowed programmatically.
+
+To achieve this, we need to add a method to the `AppDelegate` class in `AppDelegate.swift`:
+
+```swift
+func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+    return ScreenOrientationPlugin.supportedOrientations
+  }
+```
+
+Notice that the function returns `ScreenOrientationPlugin.supportedOrientations`. This property doesn’t exist yet, so let’s add it to the `ScreenOrientationPlugin` class as a private static class member:
+
+```swift
+public static var supportedOrientations = UIInterfaceOrientationMask.all
+```
+
+By setting up the code above, we tell iOS that we only want to support orientations defined by the value of `ScreenOrientationPlugin.supportedOrientations`. As you might imagine, the `UIInterfaceOrientationMask.all` enumeration value supports all orientations. We will pick a more restrictive enumeration value when we write code to lock the screen orientation.
+
+We’ll need a function that maps an OrientationType to its corresponding UIInterfaceOrientationMask enumeration value. Add the following method to the `ScreenOrientation` class:
+
+```swift
+private func fromOrientationTypeToMask(_ orientationType: String) -> UIInterfaceOrientationMask {
+  switch orientationType {
+  case "landscape-primary":
+    return UIInterfaceOrientationMask.landscapeLeft
+  case "landscape-secondary":
+    return UIInterfaceOrientationMask.landscapeRight
+  case "portrait-secondary":
+    return UIInterfaceOrientationMask.portraitUpsideDown
+  default:
+    // Case: portrait-primary
+    return UIInterfaceOrientationMask.portrait
+  }
+}
+```
+
+Forecasting into the future, we will also need a method that maps an OrientationType to an `Int`, so we’ll add it now into the `ScreenOrientation` class:
+
+```swift
+private func fromOrientationTypeToInt(_ orientationType: String) -> Int {
+  switch orientationType {
+  case "landscape-primary":
+    return UIInterfaceOrientation.landscapeLeft.rawValue
+  case "landscape-secondary":
+    return UIInterfaceOrientation.landscapeRight.rawValue
+  case "portrait-secondary":
+    return UIInterfaceOrientation.portraitUpsideDown.rawValue
+  default:
+    // Case: portrait-primary
+    return UIInterfaceOrientation.portrait.rawValue
+  }
+}
+```
+
+Now that all the setup is out of the way, we can implement the `lock()` method. Add the following method to the `ScreenOrientation` class:
+
+```swift
+public func lock(_ orientationType: String, completion: @escaping (UIInterfaceOrientationMask) -> Void) {
+  DispatchQueue.main.async {
+    let mask = self.fromOrientationTypeToMask(orientationType)
+    let orientation = self.fromOrientationTypeToInt(orientationType)
+    UIDevice.current.setValue(orientation, forKey: "orientation")
+    UINavigationController.attemptRotationToDeviceOrientation()
+    completion(mask)
+  }
+}
+```
+
+This is a complicated method; let’s walk through essential parts of it:
+
+1. `completion: @escaping (UIInterfaceOrientationMask) -> Void` tells callers of this method that they must provide a function that will be called when the method finishes execution, and we will pass the function an `UIInterfaceOrientationMask` value, by way of `completion(mask)`.
+2. `UIDevice.current.setValue(orientation, forKey: "orientation")` sets a screen orientation for the device, but does not rotate the screen to it.
+3. `UINavigationController.attemptRotationToDeviceOrientation()` will attempt to rotate the application to the screen orientation set in the previous line of code.
+4. We wrap the code in `DispatchQueue.main.async` to prevent blocking the UI thread.
+
+This method needs to get called from the `ScreenOrientationPlugin` class, and afterward, update `ScreenOrientationPlugin.supportedOrientations` so iOS knows we only want to support one specific screen orientation at this time:
+
+```swift
+​​@objc public func lock(_ call: CAPPluginCall) {
+  guard let lockToOrientation = call.getString("orientation") else {
+    call.reject("Input option 'orientation' must be provided.")
+    return
+  }
+  implementation.lock(lockToOrientation, completion: { (mask) -> Void in
+    ScreenOrientationPlugin.supportedOrientations = mask;
+    call.resolve()
+  })
+}
+```
+
+The `lock()` method also introduces a guard to prevent anyone from calling it without an `orientation` input parameter. It’s best practice to reject any calls to plugin methods that are missing any required input parameters.
+
+To unlock the screen orientation, we walk back the steps we took the lock it. Add the following method to the `ScreenOrientation` class:
+
+```swift
+public func unlock(completion: @escaping () -> Void) {
+  DispatchQueue.main.async {
+    let unknownOrientation = UIInterfaceOrientation.unknown.rawValue
+    UIDevice.current.setValue(unknownOrientation, forKey: "orientation")
+    UINavigationController.attemptRotationToDeviceOrientation()
+    completion()
+  }
+}
+```
+
+By setting the current orientation value to `UIInterfaceOrientation.unknown`, iOS attempts to auto-correct its orientation. In the `ScreenOrientationPlugin` class, we’ll revert `supportedOrientations` to `UIInterfaceOrientationMask.all`:
+
+```swift
+@objc public func unlock(_ call: CAPPluginCall) {
+  implementation.unlock {
+    ScreenOrientationPlugin.supportedOrientations = UIInterfaceOrientationMask.all
+    call.resolve()
+  }
+}
+```
+
+## Give it a test drive!
+
+In Xcode, run the app on either a device or a simulator. The plugin functions as intended! Pressing the “Rotate My Device” button will rotate the screen orientation into landscape mode, and if you rotate further, you will see that the screen orientation is locked. Pressing “Confirm Signature“ will unlock the screen orientation.
+
+The penultimate step to this tutorial is: the Android implementation.

--- a/pages/docs/v3/plugins/tutorial/packaging-the-plugin.md
+++ b/pages/docs/v3/plugins/tutorial/packaging-the-plugin.md
@@ -1,0 +1,110 @@
+---
+title: Building a Capacitor Plugin
+description: Building a Capacitor Plugin - Packaging the Plugin
+contributors:
+  - eric-horodyski
+---
+
+# Packaging the Plugin
+
+The `ScreenOrientation` plugin is functionally complete and integrated into the Capacitor application as a local plugin. However, the `ScreenOrientation` plugin can’t be used by other Capacitor applications in its current state.
+
+Let’s go ahead and package the plugin for publishing to make the `ScreenOrientation` plugin globally available.
+
+> **Note:** This section references steps and procedures from the <a href="https://capacitorjs.com/docs/plugins/creating-plugins" target="_blank">Creating Capacitor Plugins</a> portion of the Capacitor documentation. Please refer to the documentation for details beyond the scope of this tutorial.
+
+## Generating a new plugin project
+
+Capacitor has a <a href="https://github.com/ionic-team/create-capacitor-plugin" target="_blank">a plugin generator</a> we can use to scaffold a project in a format suitable for publishing a global plugin.
+
+In a new terminal, run the following command:
+
+```bash
+npx @capacitor/create-plugin \
+  --name @capacitor-community/screen-orientation \
+  --package-id io.ionic.plugins.screenorientation \
+  --class-name ScreenOrientation \
+  --repo "https://ionic.io" \
+  --license "MIT" \
+  --description "Work with the screen orientation in a common way for iOS, Android, and web"
+```
+
+When prompted to provide a directory, use the default by pressing Enter. When asked for the author’s name, use your own!
+
+## Port the plugin code
+
+Take a look at the generated project’s structure; it looks very similar to the structure built for the Capacitor application, doesn't it? 🤔
+
+Obviously, this was intentional to easily port plugin code from the Capacitor application’s codebase into the generated plugin project.
+
+Copy the contents of the files in `src/plugins/screen-orientation` into their equivalent `web.ts`, `index.ts`, and `definitions.ts` files in the plugin project.
+
+Next, copy the contents of `ScreenOrientation.swift`, `ScreenOrientationPlugin.m`, and `ScreenOrientationPlugin.swift` from one codebase to the other.
+
+Then, do the same for `ScreenOrientation.java` and `ScreenOrientationPlugin.java`. Afterward, update the package of these files in the plugin project:
+
+```java
+package io.ionic.plugins.screenorientation
+```
+
+The package name above was supplied when generating the plugin project, and any Android files in the project should use this package name.
+
+Finally, let’s verify that no issues occurred when porting over the code by running the following command:
+
+```bash
+npm run verify
+```
+
+> **Note:** You can test the plugin before publishing it by linking the plugin folder to a Capacitor project. See <a href="https://capacitorjs.com/docs/plugins/workflow#local-testing" target="_blank">Plugin Development Workflow</a> for details.
+
+## Update the plugin documentation
+
+Take a look at the plugin project’s `README.md` file; it was updated to document the plugin’s API. This update happened when we ran `npm run verify`. Any changes made to source file JSDoc comments can be reflected within the readme file’s API section by running `npm run docgen`.
+
+The plugin requires developers to modify their Capacitor application’s `AppDelegate.swift` file, so instructions on how to do so should be included in the plugin’s documentation.
+
+> **Note:** Always document any modifications developers will need to make when installing or configuring plugins you build.
+
+Replace the “Install” section of `README.md` with the following markdown:
+
+<pre>
+## Install
+
+```bash
+npm install @capacitor-community/screen-orientation
+npx cap sync
+```
+
+### iOS
+
+For iOS, you must make the following adjustments to your `AppDelegate.swift` file:
+
+```diff
+import UIKit
+...snip...
++ import CapacitorCommunityScreenOrientation
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    ...snip...
++   func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
++     return ScreenOrientationPlugin.supportedOrientations
++  }
+    ...snip...
+}
+```
+</pre>
+
+## Publishing the plugin
+
+The plugin is in a state where it can be published to an npm registry. We won’t do that in this tutorial, but note that the command to publish a Capacitor plugin project is the same as publishing any other npm package: `npm publish`.
+
+You can publish a global Capacitor plugin to the public npm registry, a private registry, or just link it to a bunch of projects locally on your machine. Whatever fits your use-case.
+
+What’s more, there is a <a href="https://github.com/capacitor-community/welcome" target="_blank">Capacitor Community GitHub organization</a> where you can get your plugin hosted and work closely with the community and Capacitor team as you continue development and maintenance on your plugin.
+
+## Conclusion
+
+Capacitor’s Plugin API is a flexible and robust solution to supplement Capacitor applications with native functionality unavailable to the web, whether the need is to add custom native code to a specific application or reuse native code between a fleet of apps.
+
+Looking forward to the plugin you develop next! 🎉

--- a/pages/docs/v3/plugins/tutorial/using-the-plugin-api.md
+++ b/pages/docs/v3/plugins/tutorial/using-the-plugin-api.md
@@ -1,0 +1,92 @@
+---
+title: Building a Capacitor Plugin
+description: Building a Capacitor Plugin - Using the Plugin API
+contributors:
+  - eric-horodyski
+---
+
+# Using the Plugin API
+
+It makes sense to build out a user interface that exercises the plugin’s API before implementing screen orientation functionality. Essentially, we want to rig up a testing harness that allows us to test feature parity across platforms quickly.
+
+The focus of this walkthrough is how to build a Capacitor plugin, not how to build an Ionic Framework application, so you can just take the finished versions of the files needed and copy and paste their contents into your project:
+
+- <a href="https://github.com/ionic-enterprise/capacitor-plugin-tutorial/blob/main/src/pages/Home.tsx" target="_blank">src/pages/Home.tsx</a>
+- <a href="https://github.com/ionic-enterprise/capacitor-plugin-tutorial/blob/main/src/pages/Home.css" target="_blank">src/pages/Home.css</a>
+
+Once copied over, serve the Capacitor app using the `ionic serve` command. Open up the browser’s Developer Tools, and you should see the following error:
+
+```bash
+Uncaught (in promise) ScreenOrientation does not have web implementation.
+```
+
+That error checks out; we haven’t implemented code for any of the platforms yet. Keep the browser open. We will implement the web platform first. Before we do, let’s review relevant code from `Home.tsx`.
+
+## How is the plugin being used?
+
+**Tracking the screen orientation:**
+
+```typescript
+const [orientation, setOrientation] = useState<string>('');
+```
+
+The `orientation` state variable is used to hold the value of the screen’s orientation. It can be updated by calling `setOrientation`. Since we don’t know the current screen orientation when the code starts executing, it’s defaulted to an empty string. A string type is used to make it easier to tell the UI which design to display.
+
+An event listener is established that updates `orientation` when `screenOrientationChange` is fired.
+
+```typescript
+ScreenOrientation.addListener('screenOrientationChange', res =>
+  setOrientation(res.type),
+);
+```
+
+The current screen orientation is obtained when the UI loads, and any listeners created (like the one above) are removed when the UI is removed from the DOM.
+
+```typescript
+useEffect(() => {
+  ScreenOrientation.orientation().then(res => setOrientation(res.type));
+
+  return () => {
+    ScreenOrientation.removeAllListeners();
+  };
+}, []);
+```
+
+Please don’t read too much into `useEffect` and the return function; those are React-specific syntax rules.
+
+**Showing the correct design:**
+
+The `OrientationType` has two values for portrait orientation: `portrait-primary` and `portrait-secondary`. The same goes for landscape orientation. Our UI doesn’t care about the difference between them, only if it is landscape or portrait.
+
+```jsx
+{
+  orientation.includes('portrait') &&
+    {
+      /* Provide a button that will rotate and lock the screen orientation to landscape mode. */
+    };
+}
+{
+  orientation.includes('landscape') &&
+    {
+      /* Let the user "sign" and unlock screen orientation through a confirmation button. */
+    };
+}
+```
+
+**Locking and unlocking screen orientation:**
+
+The portrait design contains a button that will change the screen orientation and lock it when pressed.
+
+```typescript
+onClick={() => ScreenOrientation.lock({ orientation: "landscape-primary" })}
+```
+
+Conversely, the landscape design contains a button that will unlock the screen orientation when pressed.
+
+```typescript
+onClick={() => ScreenOrientation.unlock()}
+```
+
+The rest of the code in `Home.tsx` and `Home.css` is purely cosmetic; we do not need to dig into that. Run `npm run build` so the new UI is used when we run the app on iOS or Android.
+
+We now have a user interface that exercises our plugin’s API, so let’s start implementing functionality! We will target the web first in our next step: the web implementation.

--- a/pages/docs/v3/plugins/tutorial/web-implementation.md
+++ b/pages/docs/v3/plugins/tutorial/web-implementation.md
@@ -1,0 +1,91 @@
+---
+title: Building a Capacitor Plugin
+description: Building a Capacitor Plugin - Implementing for Web/PWA
+contributors:
+  - eric-horodyski
+---
+
+# Implementing for Web/PWAs
+
+While designing the plugin’s API, we found out that the web already supports screen orientation functionality (except on mobile devices, of course). You might be asking why what would be the purpose for our plugin to have a web implementation...couldn’t you programmatically detect if the user is on the web and use the <a href="https://whatwebcando.today/screen-orientation.html" target="_blank">Screen Orientation Web API</a>, otherwise, use the plugin?
+
+The mantra behind Web Native applications is "write once, run anywhere." This applies to plugins as well; developers using Capacitor plugins ought to be able to use the same plugin class and methods and have them implemented for all platforms.
+
+Therefore, we will be good developer-citizens and wrap the Screen Orientation Web API inside the web implementation of the `ScreenOrientation` plugin.
+
+## Extending Capacitor’s WebPlugin class
+
+Open a new file `src/plugins/screen-orientation/web.ts`. This file is where we will write the web implementation of the `ScreenOrientation` plugin.
+
+Start by declaring the `ScreenOrientationWeb` class, and have it extend `WebPlugin`:
+
+```typescript
+import { WebPlugin } from '@capacitor/core';
+import type { ScreenOrientationPlugin } from './definitions';
+
+export class ScreenOrientationWeb extends WebPlugin {
+  constructor() {
+    super();
+  }
+}
+```
+
+Capacitor’s `WebPlugin` class contains logic to notify any plugin listeners, which we’ll use to tell them when the screen orientation has changed. Let’s notify any listeners when the Screen Orientation Web API’s change event fires. Update the constructor like so:
+
+```typescript
+constructor() {
+   super();
+   window.screen.orientation.addEventListener("change", () => {
+     const type = window.screen.orientation.type;
+     this.notifyListeners("screenOrientationChange", { type });
+   });
+ }
+```
+
+The `WebPlugin` class contains an implementation for the `addListener()` and `removeAllListeners()` methods defined in the `ScreenOrientationPlugin` interface. No additional work is needed to use those methods.
+
+## Implement the remaining methods
+
+Let’s finish implementing the `ScreenOrientationPlugin` interface. Start by adjusting the class definition so that it _actually_ implements the interface:
+
+```typescript
+export class ScreenOrientationWeb
+  extends WebPlugin
+  implements ScreenOrientationPlugin
+{
+```
+
+Then implement the remaining methods as part of the `ScreenOrientationWeb` class:
+
+```typescript
+ async orientation(): Promise<{ type: OrientationType }> {
+   return { type: window.screen.orientation.type };
+ }
+
+ async lock(opts: { orientation: OrientationLockType }): Promise<void> {
+   await window.screen.orientation.lock(opts.orientation);
+ }
+
+ async unlock(): Promise<void> {
+   window.screen.orientation.unlock();
+ }
+```
+
+## Registering the web implementation
+
+To register `ScreenOrientationWeb` as our plugin’s web implementation, we need to use the second input parameter of `registerPlugin()`. Open `src/plugins/screen-orientation/index.ts` and update the declaration of the `ScreenOrientation` variable like so:
+
+```typescript
+const ScreenOrientation = registerPlugin<ScreenOrientationPlugin>(
+  'ScreenOrientation',
+  {
+    web: () => import('./web').then(m => new m.ScreenOrientationWeb()),
+  },
+);
+```
+
+## Give it a test drive!
+
+Test out the web implementation. Serve your application using `ionic serve`, and you can use your browser’s Development Tools to emulate a mobile device in both portrait and landscape screen orientations. The “Rotate my Device” button doesn’t function as there is poor web support for `window.screen.orientation.lock()`, but you should be able to see the different designs if you manually rotate the orientation using the developer tooling.
+
+One platform implemented, two to go! Before diving into iOS and Android code, we should consider how to pattern and abstract it. Let’s review some patterns in the next step: code abstraction patterns.


### PR DESCRIPTION
This commit adds a section to Capacitor's Plugin documentation: Plugin Tutorial. This plugin tutorial takes users through the process of building a Capacitor plugin end-to-end, first building a plugin locally, then moving it into an isolated repository to be publishable globally via npm.  

