### PR TITLE
Update deprecated import statement

### DIFF
--- a/pages/docs/v2/apis/splash-screen/index.md
+++ b/pages/docs/v2/apis/splash-screen/index.md
@@ -25,8 +25,12 @@ The Splash Screen API provides methods for showing or hiding a Splash image.
 ## Example
 
 ```typescript
-import { Plugins } from '@capacitor/core';
-const { SplashScreen } = Plugins;
+//for capacitor v2
+//import { Plugins } from '@capacitor/core';
+//const { SplashScreen } = Plugins;
+
+//for capacitor v3 && v4
+import { SplashScreen } from '@capacitor/splash-screen';
 
 // Hide the splash (you should do this on app launch)
 SplashScreen.hide();


### PR DESCRIPTION
Capacitor v3 plugins should import the plugin directly. "Plugins" export is deprecated in v3 and will be removed in v4. So I updated the import statement for better compatibility with capacitor v3 and capacitor v4.
Also, older import statement is there for backward compatibility purposes.
![image](https://user-images.githubusercontent.com/6561498/146598349-eee1390c-6bac-4664-ac51-d6d4ab40e9e3.png)
