### PR TITLE
Update Appflow Documentation link

### DIFF
--- a/pages/docs/v2/guides/ci-cd.md
+++ b/pages/docs/v2/guides/ci-cd.md
@@ -38,7 +38,7 @@ Appflow provides frequently updated, managed iOS and Android build environments.
 
 For Capacitor developers, Appflow also offers the ability to push real-time updates to apps without app store submission, as long as those updates are at the JS/HTML/CSS layer of an app.
 
-For more details, see the [Appflow Documentation](https://ionicframework.com/docs/appflow).
+For more details, see the [Appflow Documentation](https://ionic.io/docs/appflow).
 
 ## Using a traditional CI/CD service with Appflow
 


### PR DESCRIPTION
Link to Appflow documentation hosted on the `ionic.io` domain.