### PR TITLE
fix: typo on firebase Push guide

### DIFF
--- a/pages/docs/v3/guides/push-notifications-firebase.md
+++ b/pages/docs/v3/guides/push-notifications-firebase.md
@@ -380,7 +380,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   }
 ```
 
-If you would like to recieve the firebase FCM token from iOS instead of the raw APNS token, you will need to also change your `AppDelegate.didRegisterForRemoteNotificationsWithDeviceToken` code to look like this:
+If you would like to receive the firebase FCM token from iOS instead of the raw APNS token, you will need to also change your `AppDelegate.didRegisterForRemoteNotificationsWithDeviceToken` code to look like this:
 
 ```swift
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {


### PR DESCRIPTION
Fixes a typo on the Push Notifications guide :) 