### PR TITLE
Changed to use brew install for cocoapods

### DIFF
--- a/pages/docs/v3/getting-started/environment-setup.md
+++ b/pages/docs/v3/getting-started/environment-setup.md
@@ -25,7 +25,7 @@ To build iOS apps, you will need **macOS**. You will also need to download and s
 Install [CocoaPods](https://cocoapods.org/), which is used to manage Capacitor packages for iOS.
 
 ```bash
-sudo gem install cocoapods
+brew install cocoapods
 ```
 
 ### Xcode Command Line Tools


### PR DESCRIPTION
Ruby gem installation is a pain for CocoaPods on Apple Silicon Macs. Brew  works for Apple Silicon Macs (and presumably for Intel Macs as well). See: https://github.com/CocoaPods/CocoaPods/issues/9907#issuecomment-655870749.