### PR TITLE
docs: Add registration error on firebase guide

### DIFF
--- a/pages/docs/v3/guides/push-notifications-firebase.md
+++ b/pages/docs/v3/guides/push-notifications-firebase.md
@@ -360,6 +360,25 @@ import Firebase
 FirebaseApp.configure()
 ```
 
+Then you need to add the following two methods to correctly handle the push registration events:
+
+```swift
+func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+  Messaging.messaging().apnsToken = deviceToken
+  Messaging.messaging().token(completion: { (token, error) in
+    if let error = error {
+        NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+    } else if let token = token {
+        NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: token)
+    }
+  })
+}
+
+func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+  NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+}
+```
+
 Your completed `AppDelegate.swift` file should look something like this:
 
 ```swift
@@ -378,21 +397,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     FirebaseApp.configure()
     return true
   }
-```
 
-If you would like to receive the firebase FCM token from iOS instead of the raw APNS token, you will need to also change your `AppDelegate.didRegisterForRemoteNotificationsWithDeviceToken` code to look like this:
+  func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    Messaging.messaging().apnsToken = deviceToken
+    Messaging.messaging().token(completion: { (token, error) in
+      if let error = error {
+          NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+      } else if let token = token {
+          NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: token)
+      }
+    })
+  }
 
-```swift
-    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        Messaging.messaging().apnsToken = deviceToken
-        Messaging.messaging().token(completion: { (token, error) in
-            if let error = error {
-                NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
-            } else if let token = token {
-                NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: token)
-            }
-          })
-    }
+  func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+    NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+  }
 ```
 
 ### Upload the APNS Certificate or Key to Firebase


### PR DESCRIPTION
docs were missing the didFailToRegisterForRemoteNotificationsWithError

also the didRegisterForRemoteNotificationsWithDeviceToken is no longer in the app template, so added it too and removed the section where it said you have to "change" it. 