### PR TITLE
chore: update contributing and readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-The Capacitor website (`capacitor-site/`) and documentation (`capacitor-site/pages/docs`) live alongside the code. Looking to assist? See Capacitor issues labeled "docs" [here](https://github.com/ionic-team/capacitor/issues?q=is%3Aopen+is%3Aissue+label%3Adocs).
+The Capacitor website (`capacitor-site/`).
 
 ## Setup
 
@@ -12,20 +12,6 @@ The Capacitor website (`capacitor-site/`) and documentation (`capacitor-site/pag
 
 > Note: Content updated while the dev server is running won't be reflected locally. Stop the process, then re-run `npm start`.
 
-## Adding a new page to the sidebar
+## Docs
 
-### Docs
-
-- Navigate to `capacitor-site/pages/docs/`
-- For the Guide menu, add to `capacitor-site/pages/docs/guide/README.md`
-- For the Plugins menu, add to `capacitor-site/pages/docs/plugins/README.md`
-- For the CLI menu, add to `capacitor-site/pages/docs/reference/README.md`
-
-## Modifying documentation
-
-For smaller edits, navigate to the desired page in the [Capacitor docs](https://capacitorjs.com/docs/) then click the "Submit an edit" button.
-
-1. Locate the doc you want to modify in `capacitor-site/pages/docs/`.
-1. Modify the documentation, making sure to keep the format the same as the rest of the doc.
-1. Run `npm run site-structure` to rebuild the content.
-1. Run `npm start` to make sure your changes look correct.
+Capacitor docs reside at [capacitor-docs](https://github.com/ionic-team/capacitor-docs) repository

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 # Capacitor Site
 
-The official [Capacitor](https://capacitorjs.com/) documentation, built with [Stencil](https://stenciljs.com).
+The official [Capacitor](https://capacitorjs.com/) site, built with [Stencil](https://stenciljs.com).
 
 
 ## Getting Started
@@ -23,8 +23,6 @@ The site will launch in development mode.
 ## Contributing
 
 Thanks for your interest in contributing! Read up on our guidelines for
-[contributing](https://github.com/ionic-team/capacitor-site/blob/main/CONTRIBUTING.md)
-and then look through our issues with a [docs](https://github.com/ionic-team/capacitor/issues?q=is%3Aopen+is%3Aissue+label%3Adocs)
-label.
+[contributing](https://github.com/ionic-team/capacitor-site/blob/main/CONTRIBUTING.md).
 
 Please note that this project is released with a [Contributor Code of Conduct](https://github.com/ionic-team/capacitor-site/blob/main/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.


### PR DESCRIPTION
To remove text that indicate that this repository includes the doc content, points to the new repo instead.