### PR TITLE
fix svelte solution

### DIFF
--- a/src/pages/solution-page/solution-svelte.tsx
+++ b/src/pages/solution-page/solution-svelte.tsx
@@ -23,7 +23,7 @@ export const SolutionSvelte = () => {
               language="shell-session"
               code={`
 npm install @capacitor/core @capacitor/cli
-npx cap init [name] [id] --web-dir=public
+npx cap init [name] [id]
 `}
             />
           </div>


### PR DESCRIPTION
The current svelte docs recommend using vite to create a new svelte application. By default, the vite bundler outputs to the `dist` directory instead of the `public` directory. Because of this, anyone who creates a new svelte app and then copies the code here will likely get a non-working Capacitor application. By removing this line, they'll be prompted and can (hopefully) put in the correct directory